### PR TITLE
Fix missing 'data:' in users.invite 200 response

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -4245,16 +4245,21 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "sent": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Invite"
-                      }
-                    },
-                    "users": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/User"
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "sent": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Invite"
+                          }
+                        },
+                        "users": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/User"
+                          }
+                        }
                       }
                     }
                   }

--- a/spec3.yml
+++ b/spec3.yml
@@ -2829,14 +2829,17 @@ paths:
               schema:
                 type: object
                 properties:
-                  sent:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Invite"
-                  users:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/User"
+                  data:
+                    type: object
+                    properties:
+                      sent:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Invite"
+                      users:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/User"
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "403":


### PR DESCRIPTION
The api server returns users.invite's "sent" and "users" inside "data" in the reponse.

The spec does not reflect this. Fix it.