### PR TITLE
feat: add a self-hosted server url

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -11,7 +11,16 @@
   "servers": [
     {
       "url": "https://app.getoutline.com/api",
-      "description": "Production"
+      "description": "Cloud hosted"
+    },
+    {
+      "url": "https://{domain}/api",
+      "description": "Self-hosted on your own server",
+      "variables": {
+        "domain": {
+          "default": "example.com"
+        }
+      }
     }
   ],
   "security": [

--- a/spec3.yml
+++ b/spec3.yml
@@ -150,7 +150,12 @@ info:
     email: hello@getoutline.com
 servers:
 - url: https://app.getoutline.com/api
-  description: Production
+  description: Cloud hosted
+- url: https://{domain}/api
+  description: Self-hosted on your own server
+  variables:
+    domain:
+      default: example.com
 security:
 - BearerAuth: []
 - OAuth2:


### PR DESCRIPTION
there was once a discussion about the API reference and self-hosted instances that don’t have the outline domain as the API 

https://github.com/outline/outline/discussions/7466

to address this issue, I propose to add two server URLs. one for the cloud hosted version, one for the self-hosted version.

you can preview the changes with 

```
npx @scalar/cli document serve spec3.yml
```