### PR TITLE
Fix type inconsistency in return type of `groups.add_user`

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -6,6 +6,10 @@
     "version": "0.1.0",
     "contact": {
       "email": "hello@getoutline.com"
+    },
+    "license": {
+      "name": "BSD-3-Clause",
+      "url": "https://github.com/outline/openapi/blob/main/LICENSE"
     }
   },
   "servers": [
@@ -4155,7 +4159,7 @@
                         "groupMemberships": {
                           "type": "array",
                           "items": {
-                            "$ref": "#/components/schemas/Membership"
+                            "$ref": "#/components/schemas/GroupMembership"
                           }
                         }
                       }

--- a/spec3.yml
+++ b/spec3.yml
@@ -155,6 +155,9 @@ info:
   version: 0.1.0
   contact:
     email: hello@getoutline.com
+  license:
+    name: BSD-3-Clause
+    url: https://github.com/outline/openapi/blob/main/LICENSE
 servers:
 - url: https://app.getoutline.com/api
   description: Cloud hosted

--- a/spec3.yml
+++ b/spec3.yml
@@ -2946,7 +2946,7 @@ paths:
                       groupMemberships:
                         type: array
                         items:
-                          "$ref": "#/components/schemas/Membership"
+                          "$ref": "#/components/schemas/GroupMembership"
         '400':
           "$ref": "#/components/responses/Validation"
         '401':


### PR DESCRIPTION
It seems returns `GroupMemebership` type instead `Membership` type, which is a long existed problem.

But PR https://github.com/outline/outline/pull/10030 seems to introduce the final break (incompatible `permission` type).