### PR TITLE
Add suppressEmail parameter to users.invite

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -6896,6 +6896,10 @@
                     "items": {
                       "$ref": "#/components/schemas/Invite"
                     }
+                  },
+                  "suppressEmail": {
+                    "type": "boolean",
+                    "description": "If true, the invitation emails will not be sent to the invited users. Defaults to false."
                   }
                 },
                 "required": [

--- a/spec3.yml
+++ b/spec3.yml
@@ -4768,6 +4768,9 @@ paths:
                   type: array
                   items:
                     "$ref": "#/components/schemas/Invite"
+                suppressEmail:
+                  type: boolean
+                  description: If true, the invitation emails will not be sent to the invited users. Defaults to false.
               required:
                 - invites
       responses:


### PR DESCRIPTION
## Summary

Documents the optional `suppressEmail` boolean parameter added to the `users.invite` endpoint in [outline/outline#12082](https://github.com/outline/outline/pull/12082). When set to `true`, invitation emails are not sent to the invited users.

## Other PRs reviewed (no doc changes needed)

Reviewed all PRs merged in outline/outline since 2026-04-16:

- #12083 Hebrew language — not API-relevant
- #12079 Search drafts without collection — internal logic only
- #12068 Code challenge trailing space — OAuth internal
- #12067 204 response for internal docs — `urls.unfurl` is not in the spec
- #12064, #12063 — frontend
- #12048 `collaboratorIds` default — internal model field
- Various dep bumps and chores — not API-relevant

## Test plan

- [x] `yarn lint` passes
- [x] Pre-commit hook regenerates `spec3.json`

https://claude.ai/code/session_01NM77sPzbqwjbV7Q6KyYQHk