### PR TITLE
Document patch editMode and Share allowSubscriptions

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -3301,6 +3301,10 @@
                   "editMode": {
                     "$ref": "#/components/schemas/TextEditMode"
                   },
+                  "findText": {
+                    "type": "string",
+                    "description": "The text to find within the document when using `patch` editMode. This text will be replaced with the value of `text`. Required when `editMode` is `patch`."
+                  },
                   "publish": {
                     "type": "boolean",
                     "description": "Whether this document should be published and made visible to other workspace members, if a draft"
@@ -8095,11 +8099,12 @@
       },
       "TextEditMode": {
         "type": "string",
-        "description": "The editing mode for text updates to a document.",
+        "description": "The editing mode for text updates to a document. When set to `patch`, the `findText` parameter is required and the existing occurrence of `findText` will be replaced with the value of `text`.",
         "enum": [
           "append",
           "prepend",
-          "replace"
+          "replace",
+          "patch"
         ]
       },
       "Attachment": {
@@ -8918,6 +8923,11 @@
             "type": "boolean",
             "example": true,
             "description": "If to also give permission to view documents nested beneath this one."
+          },
+          "allowSubscriptions": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether visitors to the public share can subscribe to receive email notifications when the document is updated. Requires SMTP to be configured on the workspace."
           },
           "createdAt": {
             "type": "string",

--- a/spec3.yml
+++ b/spec3.yml
@@ -2404,6 +2404,11 @@ paths:
                   description: Whether insights should be visible on the document
                 editMode:
                   "$ref": "#/components/schemas/TextEditMode"
+                findText:
+                  type: string
+                  description: The text to find within the document when using
+                    `patch` editMode. This text will be replaced with the value
+                    of `text`. Required when `editMode` is `patch`.
                 publish:
                   type: boolean
                   description: Whether this document should be published and made
@@ -5550,11 +5555,14 @@ components:
         - read_write
     TextEditMode:
       type: string
-      description: The editing mode for text updates to a document.
+      description: The editing mode for text updates to a document. When set to
+        `patch`, the `findText` parameter is required and the existing occurrence
+        of `findText` will be replaced with the value of `text`.
       enum:
         - append
         - prepend
         - replace
+        - patch
     Attachment:
       type: object
       properties:
@@ -6187,6 +6195,12 @@ components:
           example: true
           description: If to also give permission to view documents nested beneath
             this one.
+        allowSubscriptions:
+          type: boolean
+          example: true
+          description: Whether visitors to the public share can subscribe to
+            receive email notifications when the document is updated. Requires
+            SMTP to be configured on the workspace.
         createdAt:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

Updates the spec for two changes that landed in `outline/outline` over the last month:

- **`patch` editMode + `findText` parameter on `documents.update`** (outline/outline#11987)
  - Adds `patch` to the `TextEditMode` enum.
  - Documents the new `findText` request parameter, required when `editMode` is `patch`.

- **`allowSubscriptions` on `Share`** (outline/outline#11911)
  - Adds the new boolean field to the `Share` schema. Controls whether visitors to a public share can subscribe to email notifications when the document is updated.

`spec3.json` was regenerated by the pre-commit hook from `spec3.yml`.

## Test plan

- [x] `yarn validate` (spectral lint + operationId validation) passes
- [x] Pre-commit hook runs cleanly and regenerates `spec3.json`

https://claude.ai/code/session_01R65B6xHknNDgj63iQcqa4o