### PR TITLE
Document per-share branding (title and iconUrl)

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -6594,6 +6594,18 @@
                   },
                   "published": {
                     "type": "boolean"
+                  },
+                  "title": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "nullable": true,
+                    "description": "Override title displayed on the publicly shared page. If not set the source document or collection title is used."
+                  },
+                  "iconUrl": {
+                    "type": "string",
+                    "maxLength": 4096,
+                    "nullable": true,
+                    "description": "URL of an icon to display on the publicly shared page, overriding the workspace branding."
                   }
                 },
                 "required": [
@@ -9038,6 +9050,16 @@
             "format": "uri",
             "description": "URL of the publicly shared document.",
             "readOnly": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true,
+            "description": "Override title displayed on the publicly shared page. If not set the source document or collection title is used."
+          },
+          "iconUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "URL of an icon displayed on the publicly shared page, overriding the workspace branding."
           },
           "published": {
             "type": "boolean",

--- a/spec3.yml
+++ b/spec3.yml
@@ -4582,6 +4582,20 @@ paths:
                   format: uuid
                 published:
                   type: boolean
+                title:
+                  type: string
+                  maxLength: 255
+                  nullable: true
+                  description:
+                    Override title displayed on the publicly shared page. If
+                    not set the source document or collection title is used.
+                iconUrl:
+                  type: string
+                  maxLength: 4096
+                  nullable: true
+                  description:
+                    URL of an icon to display on the publicly shared page,
+                    overriding the workspace branding.
               required:
                 - id
                 - published
@@ -6275,6 +6289,18 @@ components:
           format: uri
           description: URL of the publicly shared document.
           readOnly: true
+        title:
+          type: string
+          nullable: true
+          description:
+            Override title displayed on the publicly shared page. If not set
+            the source document or collection title is used.
+        iconUrl:
+          type: string
+          nullable: true
+          description:
+            URL of an icon displayed on the publicly shared page, overriding
+            the workspace branding.
         published:
           type: boolean
           example: false


### PR DESCRIPTION
## Summary
- Adds the `title` and `iconUrl` fields to the `/shares.update` request body so a share's publicly shared page can override workspace branding.
- Adds `title` and `iconUrl` to the `Share` response schema so the same fields are documented on every endpoint that returns a share.

These reflect the API additions in [outline/outline#12003](https://github.com/outline/outline/pull/12003) ("Add per-share branding: title and logoUrl overrides"), which extended `SharesUpdateSchema` and the share presenter with these fields. Limits match `ShareValidation`: `title` ≤ 255 chars, `iconUrl` ≤ 4096 chars; both are nullable.

Only `spec3.yml` was edited by hand — `spec3.json` was regenerated by the pre-commit hook.

## Test plan
- [x] `yarn validate` passes (`spectral lint --fail-severity=error` + `validateOperationIds.js`)
- [x] Pre-commit hook regenerates `spec3.json` cleanly
- [ ] Spot-check the rendered docs for the `/shares.update` endpoint and `Share` schema

https://claude.ai/code/session_01ReQAPadYsrgjFpgobBmRRG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReQAPadYsrgjFpgobBmRRG)_