### PR TITLE
Document per-share title and iconUrl branding overrides

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -6594,6 +6594,17 @@
                   },
                   "published": {
                     "type": "boolean"
+                  },
+                  "title": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "An optional title that overrides the document title on the publicly shared page."
+                  },
+                  "iconUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 4096,
+                    "description": "An optional icon URL that overrides the workspace branding on the publicly shared page."
                   }
                 },
                 "required": [
@@ -9038,6 +9049,17 @@
             "format": "uri",
             "description": "URL of the publicly shared document.",
             "readOnly": true
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "An optional title that overrides the document title on the publicly shared page."
+          },
+          "iconUrl": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 4096,
+            "description": "An optional icon URL that overrides the workspace branding on the publicly shared page."
           },
           "published": {
             "type": "boolean",

--- a/spec3.yml
+++ b/spec3.yml
@@ -4582,6 +4582,17 @@ paths:
                   format: uuid
                 published:
                   type: boolean
+                title:
+                  type: string
+                  maxLength: 255
+                  description: An optional title that overrides the document title
+                    on the publicly shared page.
+                iconUrl:
+                  type: string
+                  format: uri
+                  maxLength: 4096
+                  description: An optional icon URL that overrides the workspace
+                    branding on the publicly shared page.
               required:
                 - id
                 - published
@@ -6275,6 +6286,17 @@ components:
           format: uri
           description: URL of the publicly shared document.
           readOnly: true
+        title:
+          type: string
+          maxLength: 255
+          description: An optional title that overrides the document title on the
+            publicly shared page.
+        iconUrl:
+          type: string
+          format: uri
+          maxLength: 4096
+          description: An optional icon URL that overrides the workspace branding
+            on the publicly shared page.
         published:
           type: boolean
           example: false


### PR DESCRIPTION
## Summary

- Adds `title` (max 255) and `iconUrl` (URI, max 4096) to the `shares.update` request body
- Adds the same two fields to the `Share` response schema

These fields were introduced upstream in outline/outline#12003, which lets a share override the workspace's document title and icon on the publicly shared page.

## Test plan

- [x] `yarn lint` passes with no errors
- [x] `yamlToJSON.js` regenerated `spec3.json` via the pre-commit hook
- [x] `validateOperationIds.js` passes

https://claude.ai/code/session_013anGcJnPJABS5Z6rWMMHPV

---
_Generated by [Claude Code](https://claude.ai/code/session_013anGcJnPJABS5Z6rWMMHPV)_