### PR TITLE
Document inline comment anchor fields on /comments.create

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -1750,7 +1750,7 @@
           "Comments"
         ],
         "summary": "Create a comment",
-        "description": "Add a comment or reply to a document, either `data` or `text` is required.",
+        "description": "Add a comment or reply to a document, either `data` or `text` is required. Provide `anchorText` to create an inline comment attached to a specific text range in the document.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1777,6 +1777,18 @@
                     "type": "string",
                     "description": "The body of the comment in markdown.",
                     "example": "Sounds great"
+                  },
+                  "anchorText": {
+                    "type": "string",
+                    "description": "Plain text substring to anchor the comment to as an inline comment. The first occurrence in the document's plain text is used unless disambiguated by `anchorPrefix` and/or `anchorSuffix`."
+                  },
+                  "anchorPrefix": {
+                    "type": "string",
+                    "description": "Text immediately preceding `anchorText`, used to disambiguate between multiple occurrences. Requires `anchorText`."
+                  },
+                  "anchorSuffix": {
+                    "type": "string",
+                    "description": "Text immediately following `anchorText`, used to disambiguate between multiple occurrences. Requires `anchorText`."
                   }
                 },
                 "required": [

--- a/spec3.yml
+++ b/spec3.yml
@@ -1366,7 +1366,10 @@ paths:
       tags:
         - Comments
       summary: Create a comment
-      description: Add a comment or reply to a document, either `data` or `text` is required.
+      description:
+        Add a comment or reply to a document, either `data` or `text` is required.
+        Provide `anchorText` to create an inline comment attached to a specific
+        text range in the document.
       requestBody:
         content:
           application/json:
@@ -1389,6 +1392,23 @@ paths:
                   type: string
                   description: The body of the comment in markdown.
                   example: Sounds great
+                anchorText:
+                  type: string
+                  description:
+                    Plain text substring to anchor the comment to as an inline
+                    comment. The first occurrence in the document's plain text
+                    is used unless disambiguated by `anchorPrefix` and/or
+                    `anchorSuffix`.
+                anchorPrefix:
+                  type: string
+                  description:
+                    Text immediately preceding `anchorText`, used to disambiguate
+                    between multiple occurrences. Requires `anchorText`.
+                anchorSuffix:
+                  type: string
+                  description:
+                    Text immediately following `anchorText`, used to disambiguate
+                    between multiple occurrences. Requires `anchorText`.
               required:
                 - documentId
       responses:


### PR DESCRIPTION
## Summary

Documents the new inline comment input parameters added to `/comments.create` in [outline/outline#12322](https://github.com/outline/outline/pull/12322) ("feat: Inline comment support").

The endpoint now accepts three optional fields for anchoring a comment to a specific text range in the document:

- `anchorText` — Plain text substring to anchor to. First occurrence in the document's plain text is used unless disambiguated.
- `anchorPrefix` — Text immediately preceding `anchorText`, used to disambiguate multiple occurrences. Requires `anchorText`.
- `anchorSuffix` — Text immediately following `anchorText`, used to disambiguate multiple occurrences. Requires `anchorText`.

The endpoint description has been updated to mention `anchorText`. The `Comment` response schema already exposes the `anchorText` field, so no response-shape changes are needed.

## Other reviewed PRs from the last day

The following merged outline/outline PRs were reviewed and determined to have no impact on the public API contract, so no doc changes were needed:

- #12332 — fix: Correct locking in comment anchor for update (internal locking only)
- #12331 — chore: Upgrade Mermaid (dependency)
- #12329 — test: Fix flaky comments.list ordering assertion (test only)
- #12328 — fix: Batch document deletes when emptying trash (internal perf only)

## Test plan

- [x] `yarn lint --fail-severity=error` passes
- [x] Husky pre-commit hook regenerated `spec3.json` from `spec3.yml`
- [x] Operation IDs validate


---
_Generated by [Claude Code](https://claude.ai/code/session_01EFvJGJxM9uBiquWQUPoHDc)_