### PR TITLE
Document period field on DocumentInsight rollups

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -2550,7 +2550,7 @@
           "Documents"
         ],
         "summary": "Retrieve insights for a document",
-        "description": "Retrieve a chronologically sorted array of daily activity rollups (views, comments, reactions, revisions, editors) for a document. Insights must be enabled on the document. Defaults to the last 30 days when no date range is provided.",
+        "description": "Retrieve a chronologically sorted array of activity rollups (views, comments, reactions, revisions, editors) for a document. Recent activity is returned as daily rollups, while older activity is aggregated into weekly rollups. Insights must be enabled on the document. Defaults to the last 30 days when no date range is provided.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9031,12 +9031,20 @@
       },
       "DocumentInsight": {
         "type": "object",
-        "description": "A daily rollup of activity counts for a document.",
+        "description": "A rollup of activity counts for a document over a daily or weekly period.",
         "properties": {
           "date": {
             "type": "string",
             "format": "date",
-            "description": "The UTC day the rollup represents."
+            "description": "The UTC day the rollup represents. For weekly rollups this is the first day (Monday) of the week."
+          },
+          "period": {
+            "type": "string",
+            "description": "The length of time the rollup covers. Daily rollups are stored for recent activity, older rollups are aggregated into weekly buckets.",
+            "enum": [
+              "day",
+              "week"
+            ]
           },
           "viewCount": {
             "type": "integer",

--- a/spec3.yml
+++ b/spec3.yml
@@ -1886,10 +1886,11 @@ paths:
       tags:
         - Documents
       summary: Retrieve insights for a document
-      description: Retrieve a chronologically sorted array of daily activity
-        rollups (views, comments, reactions, revisions, editors) for a document.
-        Insights must be enabled on the document. Defaults to the last 30 days
-        when no date range is provided.
+      description: Retrieve a chronologically sorted array of activity rollups
+        (views, comments, reactions, revisions, editors) for a document. Recent
+        activity is returned as daily rollups, while older activity is
+        aggregated into weekly rollups. Insights must be enabled on the
+        document. Defaults to the last 30 days when no date range is provided.
       requestBody:
         content:
           application/json:
@@ -6263,12 +6264,22 @@ components:
           format: date-time
     DocumentInsight:
       type: object
-      description: A daily rollup of activity counts for a document.
+      description: A rollup of activity counts for a document over a daily or weekly
+        period.
       properties:
         date:
           type: string
           format: date
-          description: The UTC day the rollup represents.
+          description: The UTC day the rollup represents. For weekly rollups this is
+            the first day (Monday) of the week.
+        period:
+          type: string
+          description: The length of time the rollup covers. Daily rollups are
+            stored for recent activity, older rollups are aggregated into
+            weekly buckets.
+          enum:
+            - day
+            - week
         viewCount:
           type: integer
           description: Total number of document views on this day.


### PR DESCRIPTION
## Summary

Updates the `DocumentInsight` response schema to document the new `period` field added in outline/outline#12113.

Recent activity is returned as daily rollups, while older activity is aggregated into weekly rollups. The new `period` enum (`day` | `week`) on each rollup tells consumers which bucket a row represents. The `date` for weekly rollups represents the first day (Monday) of the week.

Also tweaks the `/documents.insights` endpoint description to reflect that returned rollups may now be daily or weekly.

## Survey of other recent merges

Checked the other PRs merged in outline/outline since 2026-05-17 for relevance to the public API surface; none required spec updates:

- #12371 (`getJWTToken` → `getSessionToken`) — internal rename
- #12369 (remove obsolete lodash-es resolution) — deps only
- #12366 (initialize text selection state) — client-side hook
- #12335 (Comments sidebar in image lightbox) — frontend only
- #12364 (Allow connecting additional auth providers on custom domain) — internal OAuth state, no schema change
- #12361 (Refactor Markdown importer) — touches `imports.create` and `collections.import`, neither of which is currently documented in this spec

## Test plan

- [x] `yarn validate` passes (Spectral + operation IDs)
- [x] Pre-commit hook regenerated `spec3.json` from `spec3.yml`


---
_Generated by [Claude Code](https://claude.ai/code/session_014XSVjBYyPMo89LnFvPpBHN)_