### PR TITLE
Fix `FileOperation` response schema

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -9175,6 +9175,17 @@
               "export"
             ]
           },
+          "format": {
+            "type": "string",
+            "description": "The file format of the resulting file.",
+            "example": "outline-markdown",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file operation, derived from the collection name, document title, or file name.",
+            "readOnly": true
+          },
           "state": {
             "type": "string",
             "description": "The state of the file operation.",
@@ -9188,28 +9199,44 @@
               "expired"
             ]
           },
-          "collection": {
-            "allOf": [
-              {
-                "nullable": true
-              },
-              {
-                "$ref": "#/components/schemas/Collection"
-              }
-            ]
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "description": "An error message if the file operation failed.",
+            "readOnly": true
+          },
+          "size": {
+            "type": "string",
+            "description": "The size of the resulting file in bytes. Returned as a string as the value may exceed the safe integer range.",
+            "readOnly": true,
+            "example": "2048"
+          },
+          "collectionId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Identifier for the associated collection, if the file operation is scoped to a single collection.",
+            "readOnly": true,
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Identifier for the associated document, if the file operation is scoped to a single document.",
+            "readOnly": true,
+            "format": "uuid"
           },
           "user": {
             "$ref": "#/components/schemas/User"
           },
-          "size": {
-            "type": "number",
-            "description": "The size of the resulting file in bytes",
-            "readOnly": true,
-            "example": 2048
-          },
           "createdAt": {
             "type": "string",
             "description": "The date and time that this object was created",
+            "readOnly": true,
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date and time that this object was last changed",
             "readOnly": true,
             "format": "date-time"
           }

--- a/spec3.yml
+++ b/spec3.yml
@@ -6380,6 +6380,17 @@ components:
           enum:
             - import
             - export
+        format:
+          type: string
+          description: The file format of the resulting file.
+          example: outline-markdown
+          readOnly: true
+        name:
+          type: string
+          description: >-
+            The name of the file operation, derived from the collection name,
+            document title, or file name.
+          readOnly: true
         state:
           type: string
           description: The state of the file operation.
@@ -6391,20 +6402,44 @@ components:
             - complete
             - error
             - expired
-        collection:
-          allOf:
-            - nullable: true
-            - "$ref": "#/components/schemas/Collection"
+        error:
+          type: string
+          nullable: true
+          description: An error message if the file operation failed.
+          readOnly: true
+        size:
+          type: string
+          description: >-
+            The size of the resulting file in bytes. Returned as a string as the
+            value may exceed the safe integer range.
+          readOnly: true
+          example: "2048"
+        collectionId:
+          type: string
+          nullable: true
+          description: >-
+            Identifier for the associated collection, if the file operation is
+            scoped to a single collection.
+          readOnly: true
+          format: uuid
+        documentId:
+          type: string
+          nullable: true
+          description: >-
+            Identifier for the associated document, if the file operation is
+            scoped to a single document.
+          readOnly: true
+          format: uuid
         user:
           "$ref": "#/components/schemas/User"
-        size:
-          type: number
-          description: The size of the resulting file in bytes
-          readOnly: true
-          example: 2048
         createdAt:
           type: string
           description: The date and time that this object was created
+          readOnly: true
+          format: date-time
+        updatedAt:
+          type: string
+          description: The date and time that this object was last changed
           readOnly: true
           format: date-time
     Group:


### PR DESCRIPTION
The size field is backed by a BIGINT column which is serialized as a string, causing numeric validation to fail on responses like '0'. Change size to a string type.

Also align the FileOperation schema with the actual presenter output: add format, name, error, collectionId, documentId, and updatedAt, and replace the embedded collection object with collectionId.

closes https://github.com/outline/outline/issues/12535