### PR TITLE
Align response schemas with source presenters

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -9175,6 +9175,17 @@
               "export"
             ]
           },
+          "format": {
+            "type": "string",
+            "description": "The file format of the resulting file.",
+            "example": "outline-markdown",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the file operation, derived from the collection name, document title, or file name.",
+            "readOnly": true
+          },
           "state": {
             "type": "string",
             "description": "The state of the file operation.",
@@ -9188,28 +9199,44 @@
               "expired"
             ]
           },
-          "collection": {
-            "allOf": [
-              {
-                "nullable": true
-              },
-              {
-                "$ref": "#/components/schemas/Collection"
-              }
-            ]
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "description": "An error message if the file operation failed.",
+            "readOnly": true
+          },
+          "size": {
+            "type": "string",
+            "description": "The size of the resulting file in bytes. Returned as a string as the value may exceed the safe integer range.",
+            "readOnly": true,
+            "example": "2048"
+          },
+          "collectionId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Identifier for the associated collection, if the file operation is scoped to a single collection.",
+            "readOnly": true,
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Identifier for the associated document, if the file operation is scoped to a single document.",
+            "readOnly": true,
+            "format": "uuid"
           },
           "user": {
             "$ref": "#/components/schemas/User"
           },
-          "size": {
-            "type": "number",
-            "description": "The size of the resulting file in bytes",
-            "readOnly": true,
-            "example": 2048
-          },
           "createdAt": {
             "type": "string",
             "description": "The date and time that this object was created",
+            "readOnly": true,
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date and time that this object was last changed",
             "readOnly": true,
             "format": "date-time"
           }

--- a/spec3.json
+++ b/spec3.json
@@ -8579,7 +8579,8 @@
             "example": "image/png"
           },
           "size": {
-            "type": "number"
+            "type": "string",
+            "description": "The size of the attachment in bytes. Returned as a string as the value may exceed the safe integer range."
           },
           "name": {
             "type": "string"
@@ -8591,6 +8592,12 @@
           "documentId": {
             "type": "string",
             "description": "Identifier for the associated document, if any.",
+            "format": "uuid",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "description": "Identifier for the user that created the attachment.",
             "format": "uuid"
           }
         }
@@ -8667,6 +8674,11 @@
             "readOnly": true,
             "format": "uuid"
           },
+          "url": {
+            "type": "string",
+            "description": "The relative URL path at which the collection can be accessed.",
+            "readOnly": true
+          },
           "urlId": {
             "type": "string",
             "description": "A short unique identifier that can be used to identify the collection instead of the UUID.",
@@ -8680,8 +8692,14 @@
           },
           "description": {
             "type": "string",
+            "nullable": true,
             "description": "A description of the collection, may contain markdown formatting",
             "example": ""
+          },
+          "data": {
+            "type": "object",
+            "nullable": true,
+            "description": "The collection description as rich-text JSON, when available."
           },
           "sort": {
             "type": "object",
@@ -8701,25 +8719,36 @@
           },
           "index": {
             "type": "string",
+            "nullable": true,
             "description": "The position of the collection in the sidebar",
             "example": "P"
           },
           "color": {
             "type": "string",
+            "nullable": true,
             "description": "A color representing the collection, this is used to help make collections more identifiable in the UI. It should be in HEX format including the #",
             "example": "#123123"
           },
           "icon": {
             "type": "string",
+            "nullable": true,
             "description": "A string that represents an icon in the outline-icons package or an emoji"
           },
           "permission": {
+            "$ref": "#/components/schemas/Permission"
+          },
+          "templateManagement": {
             "$ref": "#/components/schemas/Permission"
           },
           "sharing": {
             "type": "boolean",
             "description": "Whether public document sharing is enabled in this collection",
             "default": false
+          },
+          "commenting": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Whether commenting is enabled in this collection"
           },
           "createdAt": {
             "type": "string",
@@ -8749,6 +8778,22 @@
           },
           "archivedBy": {
             "$ref": "#/components/schemas/User"
+          },
+          "sourceMetadata": {
+            "type": "object",
+            "nullable": true,
+            "description": "Metadata about the external source this collection was imported from, if any.",
+            "properties": {
+              "externalId": {
+                "type": "string"
+              },
+              "externalName": {
+                "type": "string"
+              },
+              "createdByName": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -8784,14 +8829,49 @@
           "createdBy": {
             "$ref": "#/components/schemas/User"
           },
+          "createdById": {
+            "type": "string",
+            "description": "Identifier for the user who created this comment.",
+            "format": "uuid",
+            "readOnly": true
+          },
           "updatedAt": {
             "type": "string",
             "description": "The date and time that this object was last changed",
             "readOnly": true,
             "format": "date-time"
           },
-          "updatedBy": {
-            "$ref": "#/components/schemas/User"
+          "resolvedAt": {
+            "type": "string",
+            "description": "The date and time that this comment was resolved, if it has been.",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          },
+          "resolvedBy": {
+            "allOf": [
+              {
+                "nullable": true
+              },
+              {
+                "$ref": "#/components/schemas/User"
+              }
+            ]
+          },
+          "resolvedById": {
+            "type": "string",
+            "description": "Identifier for the user who resolved this comment, if any.",
+            "format": "uuid",
+            "nullable": true,
+            "readOnly": true
+          },
+          "reactions": {
+            "type": "array",
+            "description": "List of emoji reactions on this comment.",
+            "items": {
+              "type": "object"
+            },
+            "readOnly": true
           },
           "anchorText": {
             "type": "string",
@@ -8888,37 +8968,6 @@
           }
         }
       },
-      "DocumentDataAttribute": {
-        "type": "object",
-        "properties": {
-          "dataAttributeId": {
-            "type": "string",
-            "description": "Unique identifier for the associated data attribute.",
-            "format": "uuid"
-          },
-          "value": {
-            "description": "The value of the data attribute for this document.",
-            "example": "In Progress",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "number"
-              }
-            ]
-          },
-          "updatedAt": {
-            "type": "string",
-            "description": "The date and time that this object attribute was last changed",
-            "readOnly": true,
-            "format": "date-time"
-          }
-        }
-      },
       "Document": {
         "type": "object",
         "properties": {
@@ -8931,12 +8980,14 @@
           "collectionId": {
             "type": "string",
             "description": "Identifier for the associated collection.",
-            "format": "uuid"
+            "format": "uuid",
+            "nullable": true
           },
           "parentDocumentId": {
             "type": "string",
             "description": "Identifier for the document this is a child of, if any.",
-            "format": "uuid"
+            "format": "uuid",
+            "nullable": true
           },
           "title": {
             "type": "string",
@@ -8947,30 +8998,56 @@
             "type": "boolean",
             "description": "Whether this document should be displayed in a full-width view."
           },
-          "emoji": {
+          "icon": {
             "type": "string",
-            "description": "An emoji associated with the document.",
+            "nullable": true,
+            "description": "An emoji or icon associated with the document.",
             "example": "🎉"
+          },
+          "color": {
+            "type": "string",
+            "nullable": true,
+            "description": "The color of the document icon in hex format."
           },
           "text": {
             "type": "string",
             "description": "The text content of the document, contains markdown formatting",
             "example": "…"
           },
+          "data": {
+            "type": "object",
+            "nullable": true,
+            "description": "The body of the document as a Prosemirror document, returned in place of text when requested."
+          },
+          "url": {
+            "type": "string",
+            "description": "A URL path to access the document.",
+            "readOnly": true
+          },
           "urlId": {
             "type": "string",
             "description": "A short unique ID that can be used to identify the document as an alternative to the UUID",
             "example": "hDYep1TPAM"
           },
-          "collaborators": {
+          "collaboratorIds": {
             "type": "array",
+            "description": "Identifiers of users who have edited the document.",
             "items": {
-              "$ref": "#/components/schemas/User"
+              "type": "string",
+              "format": "uuid"
             }
           },
-          "pinned": {
-            "type": "boolean",
-            "description": "Whether this document is pinned in the collection"
+          "tasks": {
+            "type": "object",
+            "description": "Task completion counts for the document.",
+            "properties": {
+              "completed": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              }
+            }
           },
           "templateId": {
             "type": "string",
@@ -9007,15 +9084,9 @@
             "readOnly": true,
             "format": "date-time"
           },
-          "dataAttributes": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "$ref": "#/components/schemas/DocumentDataAttribute"
-            }
-          },
           "archivedAt": {
             "type": "string",
+            "nullable": true,
             "description": "The date and time that this object was archived",
             "readOnly": true,
             "format": "date-time"
@@ -9092,6 +9163,12 @@
             "format": "uuid",
             "readOnly": true
           },
+          "userId": {
+            "type": "string",
+            "description": "Identifier for the user associated with the event, if any.",
+            "format": "uuid",
+            "readOnly": true
+          },
           "actorId": {
             "type": "string",
             "description": "The user that performed the action.",
@@ -9128,6 +9205,12 @@
               "name": "Equipment list"
             },
             "description": "Additional unstructured data associated with the event",
+            "readOnly": true
+          },
+          "changes": {
+            "type": "object",
+            "nullable": true,
+            "description": "The set of changes made by this event. This field is only returned when the `auditLog` boolean is true.",
             "readOnly": true
           },
           "actor": {
@@ -9256,6 +9339,25 @@
             "description": "The name of this group.",
             "example": "Engineering"
           },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "A short description of this group."
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true,
+            "description": "An identifier for this group in an external system, if linked."
+          },
+          "disableMentions": {
+            "type": "boolean",
+            "description": "Whether mentioning this group is disabled."
+          },
+          "externalGroup": {
+            "type": "object",
+            "nullable": true,
+            "description": "Details of the linked external group, if any."
+          },
           "memberCount": {
             "type": "number",
             "description": "The number of users that are members of the group",
@@ -9292,21 +9394,25 @@
           },
           "description": {
             "type": "string",
+            "nullable": true,
             "description": "A short description of this OAuth client.",
             "example": "Integrate Acme Inc's services into Outline."
           },
           "developerName": {
             "type": "string",
+            "nullable": true,
             "description": "The name of the developer who created this OAuth client.",
             "example": "Acme Inc"
           },
           "developerUrl": {
             "type": "string",
+            "nullable": true,
             "description": "The URL of the developer who created this OAuth client.",
             "example": "https://example.com"
           },
           "avatarUrl": {
             "type": "string",
+            "nullable": true,
             "description": "A URL pointing to an image representing the OAuth client."
           },
           "clientId": {
@@ -9320,6 +9426,15 @@
             "description": "The client secret for the OAuth client.",
             "readOnly": true,
             "example": "ol_sk_rapdv31..."
+          },
+          "clientType": {
+            "type": "string",
+            "description": "The type of the OAuth client.",
+            "readOnly": true,
+            "enum": [
+              "public",
+              "confidential"
+            ]
           },
           "redirectUris": {
             "type": "array",
@@ -9335,6 +9450,13 @@
             "type": "boolean",
             "description": "Whether the OAuth client is available to other workspaces.",
             "example": true
+          },
+          "lastActiveAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date and time when this OAuth client was last used.",
+            "readOnly": true
           },
           "createdAt": {
             "type": "string",
@@ -9365,6 +9487,38 @@
             "readOnly": true,
             "format": "uuid"
           },
+          "oauthClient": {
+            "type": "object",
+            "readOnly": true,
+            "description": "A reduced, public representation of the associated OAuth client.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string",
+                "nullable": true
+              },
+              "developerName": {
+                "type": "string",
+                "nullable": true
+              },
+              "developerUrl": {
+                "type": "string",
+                "nullable": true
+              },
+              "avatarUrl": {
+                "type": "string",
+                "nullable": true
+              },
+              "clientId": {
+                "type": "string"
+              },
+              "published": {
+                "type": "boolean"
+              }
+            }
+          },
           "userId": {
             "type": "string",
             "description": "Identifier for the associated User.",
@@ -9381,6 +9535,12 @@
             "type": "string",
             "format": "date-time",
             "description": "Date and time when this authentication was last used",
+            "readOnly": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time when this authentication was created",
             "readOnly": true
           }
         }
@@ -9405,10 +9565,39 @@
             "description": "Title of the document.",
             "readOnly": true
           },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "The name of the revision, if any.",
+            "readOnly": true
+          },
+          "data": {
+            "type": "object",
+            "description": "The body of the revision as a Prosemirror document.",
+            "readOnly": true
+          },
           "text": {
             "type": "string",
             "description": "Body of the document, may contain markdown formatting",
             "readOnly": true
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true,
+            "description": "An emoji or icon associated with the revision.",
+            "readOnly": true
+          },
+          "color": {
+            "type": "string",
+            "nullable": true,
+            "description": "The color of the revision icon in hex format.",
+            "readOnly": true
+          },
+          "collaborators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
           },
           "createdAt": {
             "type": "string",
@@ -9418,6 +9607,19 @@
           },
           "createdBy": {
             "$ref": "#/components/schemas/User"
+          },
+          "createdById": {
+            "type": "string",
+            "description": "Identifier for the user who created this revision.",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date and time when this revision was deleted, if applicable.",
+            "readOnly": true
           }
         }
       },
@@ -9442,11 +9644,46 @@
             "description": "URL of the original document.",
             "readOnly": true
           },
+          "sourceTitle": {
+            "type": "string",
+            "description": "Title of the shared document or collection.",
+            "readOnly": true
+          },
+          "sourcePath": {
+            "type": "string",
+            "description": "Path of the shared document or collection.",
+            "readOnly": true
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Identifier of the shared document, if any.",
+            "readOnly": true
+          },
+          "collectionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Identifier of the shared collection, if any.",
+            "readOnly": true
+          },
+          "urlId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Short URL identifier for the share, if set.",
+            "readOnly": true
+          },
           "url": {
             "type": "string",
             "format": "uri",
             "description": "URL of the publicly shared document.",
             "readOnly": true
+          },
+          "domain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Custom domain the share is served on, if any."
           },
           "title": {
             "type": "string",
@@ -9476,6 +9713,23 @@
             "example": true,
             "description": "Whether visitors to the public share can subscribe to receive email notifications when the document is updated. Requires SMTP to be configured on the workspace."
           },
+          "allowIndexing": {
+            "type": "boolean",
+            "description": "Whether the shared page may be indexed by search engines."
+          },
+          "showLastUpdated": {
+            "type": "boolean",
+            "description": "Whether to show the last-updated time on the shared page."
+          },
+          "showTOC": {
+            "type": "boolean",
+            "description": "Whether to show a table of contents on the shared page."
+          },
+          "views": {
+            "type": "number",
+            "description": "The number of times the shared page has been viewed.",
+            "readOnly": true
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -9494,7 +9748,8 @@
           "lastAccessedAt": {
             "type": "string",
             "format": "date-time",
-            "description": "Date and time when this share was last viewed",
+            "nullable": true,
+            "description": "Date and time when this share was last viewed. Only returned to workspace admins.",
             "readOnly": true
           }
         }
@@ -9516,24 +9771,26 @@
             "type": "string",
             "description": "Unique identifier for the starred document.",
             "readOnly": true,
-            "format": "uuid"
+            "format": "uuid",
+            "nullable": true
           },
           "collectionId": {
             "type": "string",
             "description": "Unique identifier for the starred collection.",
             "readOnly": true,
-            "format": "uuid"
-          },
-          "documentUrl": {
-            "type": "string",
-            "format": "uri",
-            "description": "URL of the original document.",
-            "readOnly": true
+            "format": "uuid",
+            "nullable": true
           },
           "createdAt": {
             "type": "string",
             "format": "date-time",
             "description": "Date and time when this star was created",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time when this star was last changed",
             "readOnly": true
           }
         }
@@ -9550,6 +9807,11 @@
           "name": {
             "type": "string",
             "description": "The name of this workspace, it is usually auto-generated when the first SSO connection is made but can be changed if necessary."
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "A short description of this workspace."
           },
           "avatarUrl": {
             "type": "string",
@@ -9572,13 +9834,13 @@
             "type": "boolean",
             "description": "Whether members are allowed to create new collections. If false then only admins can create collections."
           },
+          "memberTeamCreate": {
+            "type": "boolean",
+            "description": "Whether members are allowed to create new groups. If false then only admins can create groups."
+          },
           "documentEmbeds": {
             "type": "boolean",
             "description": "Whether this workspace has embeds in documents globally enabled. It can be disabled to reduce potential data leakage to third parties."
-          },
-          "collaborativeEditing": {
-            "type": "boolean",
-            "description": "Whether this workspace has collaborative editing in documents globally enabled."
           },
           "inviteRequired": {
             "type": "boolean",
@@ -9599,11 +9861,30 @@
             "type": "string",
             "description": "Represents the subdomain at which this workspace's knowledge base can be accessed."
           },
+          "domain": {
+            "type": "string",
+            "nullable": true,
+            "description": "The custom domain configured for this workspace, if any."
+          },
           "url": {
             "type": "string",
             "description": "The fully qualified URL at which this workspace's knowledge base can be accessed.",
             "readOnly": true,
             "format": "uri"
+          },
+          "passkeysEnabled": {
+            "type": "boolean",
+            "description": "Whether passkey authentication is enabled for this workspace."
+          },
+          "preferences": {
+            "type": "object",
+            "nullable": true,
+            "description": "Workspace-level preference flags."
+          },
+          "guidanceMCP": {
+            "type": "string",
+            "nullable": true,
+            "description": "Guidance text provided to MCP integrations."
           }
         }
       },
@@ -9626,6 +9907,11 @@
             "format": "uri",
             "description": "The URL for the image associated with this user, it will be displayed in the application UI and email notifications."
           },
+          "color": {
+            "type": "string",
+            "description": "A color representing the user, used in the UI for avatars without an image.",
+            "readOnly": true
+          },
           "email": {
             "type": "string",
             "description": "The email associated with this user, it is migrated from Slack or Google Workspace when the SSO connection is made but can be changed if necessary.",
@@ -9642,13 +9928,32 @@
           },
           "lastActiveAt": {
             "type": "string",
+            "nullable": true,
             "description": "The last time this user made an API request, this value is updated at most every 5 minutes.",
             "readOnly": true,
             "format": "date-time"
           },
+          "timezone": {
+            "type": "string",
+            "nullable": true,
+            "description": "The timezone this user has registered."
+          },
           "createdAt": {
             "type": "string",
             "description": "The date and time that this user first signed in or was invited as a guest.",
+            "readOnly": true,
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date and time that this user was last updated.",
+            "readOnly": true,
+            "format": "date-time"
+          },
+          "deletedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "The date and time that this user was deleted, if applicable.",
             "readOnly": true,
             "format": "date-time"
           }
@@ -9699,14 +10004,40 @@
             "readOnly": true,
             "format": "uuid"
           },
+          "documentId": {
+            "type": "string",
+            "description": "Identifier for the associated document, if any.",
+            "readOnly": true,
+            "format": "uuid",
+            "nullable": true
+          },
           "collectionId": {
             "type": "string",
-            "description": "Identifier for the associated collection.",
+            "description": "Identifier for the associated collection, if any.",
             "readOnly": true,
-            "format": "uuid"
+            "format": "uuid",
+            "nullable": true
           },
           "permission": {
             "$ref": "#/components/schemas/Permission"
+          },
+          "createdById": {
+            "type": "string",
+            "description": "Identifier for the user who created this membership.",
+            "readOnly": true,
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "description": "Identifier for the membership this one was inherited from, if any.",
+            "readOnly": true,
+            "format": "uuid",
+            "nullable": true
+          },
+          "index": {
+            "type": "string",
+            "description": "The position of the collection in the user's sidebar.",
+            "nullable": true
           }
         }
       },
@@ -9800,14 +10131,29 @@
             "readOnly": true,
             "format": "uuid"
           },
-          "userId": {
+          "documentId": {
             "type": "string",
-            "description": "Identifier for the associated user.",
+            "description": "Identifier for the associated document, if any.",
             "readOnly": true,
-            "format": "uuid"
+            "format": "uuid",
+            "nullable": true
           },
-          "user": {
-            "$ref": "#/components/schemas/User"
+          "collectionId": {
+            "type": "string",
+            "description": "Identifier for the associated collection, if any.",
+            "readOnly": true,
+            "format": "uuid",
+            "nullable": true
+          },
+          "permission": {
+            "$ref": "#/components/schemas/Permission"
+          },
+          "sourceId": {
+            "type": "string",
+            "description": "Identifier for the membership this one was inherited from, if any.",
+            "readOnly": true,
+            "format": "uuid",
+            "nullable": true
           }
         }
       },
@@ -9825,14 +10171,29 @@
             "readOnly": true,
             "format": "uuid"
           },
+          "documentId": {
+            "type": "string",
+            "description": "Identifier for the associated document, if any.",
+            "readOnly": true,
+            "format": "uuid",
+            "nullable": true
+          },
           "collectionId": {
             "type": "string",
-            "description": "Identifier for the associated collection.",
+            "description": "Identifier for the associated collection, if any.",
             "readOnly": true,
-            "format": "uuid"
+            "format": "uuid",
+            "nullable": true
           },
           "permission": {
             "$ref": "#/components/schemas/Permission"
+          },
+          "sourceId": {
+            "type": "string",
+            "description": "Identifier for the membership this one was inherited from, if any.",
+            "readOnly": true,
+            "format": "uuid",
+            "nullable": true
           }
         }
       },
@@ -9910,6 +10271,7 @@
           },
           "publishedAt": {
             "type": "string",
+            "nullable": true,
             "description": "The date and time that the template was published.",
             "readOnly": true,
             "format": "date-time"
@@ -9946,6 +10308,12 @@
             "type": "number",
             "description": "The number of times the user has viewed the document.",
             "example": 22,
+            "readOnly": true
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the user who viewed the document.",
             "readOnly": true
           },
           "user": {

--- a/spec3.json
+++ b/spec3.json
@@ -8968,6 +8968,37 @@
           }
         }
       },
+      "DocumentDataAttribute": {
+        "type": "object",
+        "properties": {
+          "dataAttributeId": {
+            "type": "string",
+            "description": "Unique identifier for the associated data attribute.",
+            "format": "uuid"
+          },
+          "value": {
+            "description": "The value of the data attribute for this document.",
+            "example": "In Progress",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date and time that this object attribute was last changed",
+            "readOnly": true,
+            "format": "date-time"
+          }
+        }
+      },
       "Document": {
         "type": "object",
         "properties": {
@@ -9083,6 +9114,13 @@
             "description": "The date and time that this object was published",
             "readOnly": true,
             "format": "date-time"
+          },
+          "dataAttributes": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/DocumentDataAttribute"
+            }
           },
           "archivedAt": {
             "type": "string",

--- a/spec3.yml
+++ b/spec3.yml
@@ -6216,6 +6216,25 @@ components:
               color:
                 type: string
                 description: Optional color for the option.
+    DocumentDataAttribute:
+      type: object
+      properties:
+        dataAttributeId:
+          type: string
+          description: Unique identifier for the associated data attribute.
+          format: uuid
+        value:
+          description: The value of the data attribute for this document.
+          example: In Progress
+          oneOf:
+            - type: string
+            - type: boolean
+            - type: number
+        updatedAt:
+          type: string
+          description: The date and time that this object attribute was last changed
+          readOnly: true
+          format: date-time
     Document:
       type: object
       properties:
@@ -6312,6 +6331,11 @@ components:
           description: The date and time that this object was published
           readOnly: true
           format: date-time
+        dataAttributes:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/DocumentDataAttribute"
         archivedAt:
           type: string
           nullable: true

--- a/spec3.yml
+++ b/spec3.yml
@@ -5918,7 +5918,10 @@ components:
           type: string
           example: image/png
         size:
-          type: number
+          type: string
+          description: >-
+            The size of the attachment in bytes. Returned as a string as the
+            value may exceed the safe integer range.
         name:
           type: string
         url:
@@ -5927,6 +5930,11 @@ components:
         documentId:
           type: string
           description: Identifier for the associated document, if any.
+          format: uuid
+          nullable: true
+        userId:
+          type: string
+          description: Identifier for the user that created the attachment.
           format: uuid
     Pagination:
       type: object
@@ -5979,6 +5987,10 @@ components:
           description: Unique identifier for the object.
           readOnly: true
           format: uuid
+        url:
+          type: string
+          description: The relative URL path at which the collection can be accessed.
+          readOnly: true
         urlId:
           type: string
           description: A short unique identifier that can be used to identify the
@@ -5991,8 +6003,13 @@ components:
           example: Human Resources
         description:
           type: string
+          nullable: true
           description: A description of the collection, may contain markdown formatting
           example: ""
+        data:
+          type: object
+          nullable: true
+          description: The collection description as rich-text JSON, when available.
         sort:
           type: object
           description: The sort of documents in the collection. Note that not all
@@ -6007,23 +6024,32 @@ components:
                 - desc
         index:
           type: string
+          nullable: true
           description: The position of the collection in the sidebar
           example: P
         color:
           type: string
+          nullable: true
           description: "A color representing the collection, this is used to help
             make collections more identifiable in the UI. It should be in HEX format
             including the #"
           example: "#123123"
         icon:
           type: string
+          nullable: true
           description: A string that represents an icon in the outline-icons package or an emoji
         permission:
+          "$ref": "#/components/schemas/Permission"
+        templateManagement:
           "$ref": "#/components/schemas/Permission"
         sharing:
           type: boolean
           description: Whether public document sharing is enabled in this collection
           default: false
+        commenting:
+          type: boolean
+          nullable: true
+          description: Whether commenting is enabled in this collection
         createdAt:
           type: string
           description: The date and time that this object was created
@@ -6048,6 +6074,17 @@ components:
           format: date-time
         archivedBy:
           "$ref": "#/components/schemas/User"
+        sourceMetadata:
+          type: object
+          nullable: true
+          description: Metadata about the external source this collection was imported from, if any.
+          properties:
+            externalId:
+              type: string
+            externalName:
+              type: string
+            createdByName:
+              type: string
     Comment:
       type: object
       properties:
@@ -6074,13 +6111,38 @@ components:
           format: date-time
         createdBy:
           "$ref": "#/components/schemas/User"
+        createdById:
+          type: string
+          description: Identifier for the user who created this comment.
+          format: uuid
+          readOnly: true
         updatedAt:
           type: string
           description: The date and time that this object was last changed
           readOnly: true
           format: date-time
-        updatedBy:
-          "$ref": "#/components/schemas/User"
+        resolvedAt:
+          type: string
+          description: The date and time that this comment was resolved, if it has been.
+          format: date-time
+          nullable: true
+          readOnly: true
+        resolvedBy:
+          allOf:
+            - nullable: true
+            - "$ref": "#/components/schemas/User"
+        resolvedById:
+          type: string
+          description: Identifier for the user who resolved this comment, if any.
+          format: uuid
+          nullable: true
+          readOnly: true
+        reactions:
+          type: array
+          description: List of emoji reactions on this comment.
+          items:
+            type: object
+          readOnly: true
         anchorText:
           type: string
           description:
@@ -6154,25 +6216,6 @@ components:
               color:
                 type: string
                 description: Optional color for the option.
-    DocumentDataAttribute:
-      type: object
-      properties:
-        dataAttributeId:
-          type: string
-          description: Unique identifier for the associated data attribute.
-          format: uuid
-        value:
-          description: The value of the data attribute for this document.
-          example: In Progress
-          oneOf:
-            - type: string
-            - type: boolean
-            - type: number
-        updatedAt:
-          type: string
-          description: The date and time that this object attribute was last changed
-          readOnly: true
-          format: date-time
     Document:
       type: object
       properties:
@@ -6185,10 +6228,12 @@ components:
           type: string
           description: Identifier for the associated collection.
           format: uuid
+          nullable: true
         parentDocumentId:
           type: string
           description: Identifier for the document this is a child of, if any.
           format: uuid
+          nullable: true
         title:
           type: string
           description: The title of the document.
@@ -6196,26 +6241,47 @@ components:
         fullWidth:
           type: boolean
           description: Whether this document should be displayed in a full-width view.
-        emoji:
+        icon:
           type: string
-          description: An emoji associated with the document.
+          nullable: true
+          description: An emoji or icon associated with the document.
           example: "\U0001F389"
+        color:
+          type: string
+          nullable: true
+          description: The color of the document icon in hex format.
         text:
           type: string
           description: The text content of the document, contains markdown formatting
           example: "…"
+        data:
+          type: object
+          nullable: true
+          description: The body of the document as a Prosemirror document, returned
+            in place of text when requested.
+        url:
+          type: string
+          description: A URL path to access the document.
+          readOnly: true
         urlId:
           type: string
           description: A short unique ID that can be used to identify the document
             as an alternative to the UUID
           example: hDYep1TPAM
-        collaborators:
+        collaboratorIds:
           type: array
+          description: Identifiers of users who have edited the document.
           items:
-            "$ref": "#/components/schemas/User"
-        pinned:
-          type: boolean
-          description: Whether this document is pinned in the collection
+            type: string
+            format: uuid
+        tasks:
+          type: object
+          description: Task completion counts for the document.
+          properties:
+            completed:
+              type: number
+            total:
+              type: number
         templateId:
           type: string
           description: Unique identifier for the template this document was created
@@ -6246,13 +6312,9 @@ components:
           description: The date and time that this object was published
           readOnly: true
           format: date-time
-        dataAttributes:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/DocumentDataAttribute"
         archivedAt:
           type: string
+          nullable: true
           description: The date and time that this object was archived
           readOnly: true
           format: date-time
@@ -6316,6 +6378,11 @@ components:
             it is not one of document, collection, or user.
           format: uuid
           readOnly: true
+        userId:
+          type: string
+          description: Identifier for the user associated with the event, if any.
+          format: uuid
+          readOnly: true
         actorId:
           type: string
           description: The user that performed the action.
@@ -6347,6 +6414,12 @@ components:
           example:
             name: Equipment list
           description: Additional unstructured data associated with the event
+          readOnly: true
+        changes:
+          type: object
+          nullable: true
+          description: The set of changes made by this event. This field is only
+            returned when the `auditLog` boolean is true.
           readOnly: true
         actor:
           "$ref": "#/components/schemas/User"
@@ -6454,6 +6527,21 @@ components:
           type: string
           description: The name of this group.
           example: Engineering
+        description:
+          type: string
+          nullable: true
+          description: A short description of this group.
+        externalId:
+          type: string
+          nullable: true
+          description: An identifier for this group in an external system, if linked.
+        disableMentions:
+          type: boolean
+          description: Whether mentioning this group is disabled.
+        externalGroup:
+          type: object
+          nullable: true
+          description: Details of the linked external group, if any.
         memberCount:
           type: number
           description: The number of users that are members of the group
@@ -6483,18 +6571,22 @@ components:
           example: Acme Inc
         description:
           type: string
+          nullable: true
           description: A short description of this OAuth client.
           example: Integrate Acme Inc's services into Outline.
         developerName:
           type: string
+          nullable: true
           description: The name of the developer who created this OAuth client.
           example: Acme Inc
         developerUrl:
           type: string
+          nullable: true
           description: The URL of the developer who created this OAuth client.
           example: https://example.com
         avatarUrl:
           type: string
+          nullable: true
           description: A URL pointing to an image representing the OAuth client.
         clientId:
           type: string
@@ -6506,6 +6598,13 @@ components:
           description: The client secret for the OAuth client.
           readOnly: true
           example: ol_sk_rapdv31...
+        clientType:
+          type: string
+          description: The type of the OAuth client.
+          readOnly: true
+          enum:
+            - public
+            - confidential
         redirectUris:
           type: array
           items:
@@ -6516,6 +6615,12 @@ components:
           type: boolean
           description: Whether the OAuth client is available to other workspaces.
           example: true
+        lastActiveAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Date and time when this OAuth client was last used.
+          readOnly: true
         createdAt:
           type: string
           format: date-time
@@ -6539,6 +6644,29 @@ components:
           description: Identifier for the associated OAuthClient.
           readOnly: true
           format: uuid
+        oauthClient:
+          type: object
+          readOnly: true
+          description: A reduced, public representation of the associated OAuth client.
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+              nullable: true
+            developerName:
+              type: string
+              nullable: true
+            developerUrl:
+              type: string
+              nullable: true
+            avatarUrl:
+              type: string
+              nullable: true
+            clientId:
+              type: string
+            published:
+              type: boolean
         userId:
           type: string
           description: Identifier for the associated User.
@@ -6552,6 +6680,11 @@ components:
           type: string
           format: date-time
           description: Date and time when this authentication was last used
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Date and time when this authentication was created
           readOnly: true
 
     Revision:
@@ -6571,10 +6704,33 @@ components:
           type: string
           description: Title of the document.
           readOnly: true
+        name:
+          type: string
+          nullable: true
+          description: The name of the revision, if any.
+          readOnly: true
+        data:
+          type: object
+          description: The body of the revision as a Prosemirror document.
+          readOnly: true
         text:
           type: string
           description: Body of the document, may contain markdown formatting
           readOnly: true
+        icon:
+          type: string
+          nullable: true
+          description: An emoji or icon associated with the revision.
+          readOnly: true
+        color:
+          type: string
+          nullable: true
+          description: The color of the revision icon in hex format.
+          readOnly: true
+        collaborators:
+          type: array
+          items:
+            "$ref": "#/components/schemas/User"
         createdAt:
           type: string
           format: date-time
@@ -6582,6 +6738,17 @@ components:
           readOnly: true
         createdBy:
           "$ref": "#/components/schemas/User"
+        createdById:
+          type: string
+          description: Identifier for the user who created this revision.
+          format: uuid
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Date and time when this revision was deleted, if applicable.
+          readOnly: true
     Share:
       type: object
       properties:
@@ -6600,11 +6767,40 @@ components:
           format: uri
           description: URL of the original document.
           readOnly: true
+        sourceTitle:
+          type: string
+          description: Title of the shared document or collection.
+          readOnly: true
+        sourcePath:
+          type: string
+          description: Path of the shared document or collection.
+          readOnly: true
+        documentId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Identifier of the shared document, if any.
+          readOnly: true
+        collectionId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Identifier of the shared collection, if any.
+          readOnly: true
+        urlId:
+          type: string
+          nullable: true
+          description: Short URL identifier for the share, if set.
+          readOnly: true
         url:
           type: string
           format: uri
           description: URL of the publicly shared document.
           readOnly: true
+        domain:
+          type: string
+          nullable: true
+          description: Custom domain the share is served on, if any.
         title:
           type: string
           maxLength: 255
@@ -6635,6 +6831,19 @@ components:
           description: Whether visitors to the public share can subscribe to
             receive email notifications when the document is updated. Requires
             SMTP to be configured on the workspace.
+        allowIndexing:
+          type: boolean
+          description: Whether the shared page may be indexed by search engines.
+        showLastUpdated:
+          type: boolean
+          description: Whether to show the last-updated time on the shared page.
+        showTOC:
+          type: boolean
+          description: Whether to show a table of contents on the shared page.
+        views:
+          type: number
+          description: The number of times the shared page has been viewed.
+          readOnly: true
         createdAt:
           type: string
           format: date-time
@@ -6650,7 +6859,9 @@ components:
         lastAccessedAt:
           type: string
           format: date-time
-          description: Date and time when this share was last viewed
+          nullable: true
+          description: Date and time when this share was last viewed. Only returned
+            to workspace admins.
           readOnly: true
     Star:
       type: object
@@ -6668,20 +6879,22 @@ components:
           description: Unique identifier for the starred document.
           readOnly: true
           format: uuid
+          nullable: true
         collectionId:
           type: string
           description: Unique identifier for the starred collection.
           readOnly: true
           format: uuid
-        documentUrl:
-          type: string
-          format: uri
-          description: URL of the original document.
-          readOnly: true
+          nullable: true
         createdAt:
           type: string
           format: date-time
           description: Date and time when this star was created
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          description: Date and time when this star was last changed
           readOnly: true
     Team:
       type: object
@@ -6696,6 +6909,10 @@ components:
           description:
             The name of this workspace, it is usually auto-generated when the
             first SSO connection is made but can be changed if necessary.
+        description:
+          type: string
+          nullable: true
+          description: A short description of this workspace.
         avatarUrl:
           type: string
           format: uri
@@ -6720,16 +6937,16 @@ components:
           description:
             Whether members are allowed to create new collections. If false
             then only admins can create collections.
+        memberTeamCreate:
+          type: boolean
+          description:
+            Whether members are allowed to create new groups. If false then only
+            admins can create groups.
         documentEmbeds:
           type: boolean
           description:
             Whether this workspace has embeds in documents globally enabled.
             It can be disabled to reduce potential data leakage to third parties.
-        collaborativeEditing:
-          type: boolean
-          description:
-            Whether this workspace has collaborative editing in documents globally
-            enabled.
         inviteRequired:
           type: boolean
           description:
@@ -6751,6 +6968,10 @@ components:
           description:
             Represents the subdomain at which this workspace's knowledge base
             can be accessed.
+        domain:
+          type: string
+          nullable: true
+          description: The custom domain configured for this workspace, if any.
         url:
           type: string
           description:
@@ -6758,6 +6979,17 @@ components:
             can be accessed.
           readOnly: true
           format: uri
+        passkeysEnabled:
+          type: boolean
+          description: Whether passkey authentication is enabled for this workspace.
+        preferences:
+          type: object
+          nullable: true
+          description: Workspace-level preference flags.
+        guidanceMCP:
+          type: string
+          nullable: true
+          description: Guidance text provided to MCP integrations.
     User:
       type: object
       properties:
@@ -6776,6 +7008,11 @@ components:
           format: uri
           description: The URL for the image associated with this user, it will be
             displayed in the application UI and email notifications.
+        color:
+          type: string
+          description: A color representing the user, used in the UI for avatars
+            without an image.
+          readOnly: true
         email:
           type: string
           description: The email associated with this user, it is migrated from Slack
@@ -6791,15 +7028,31 @@ components:
           readOnly: true
         lastActiveAt:
           type: string
+          nullable: true
           description: The last time this user made an API request, this value is
             updated at most every 5 minutes.
           readOnly: true
           format: date-time
+        timezone:
+          type: string
+          nullable: true
+          description: The timezone this user has registered.
         createdAt:
           type: string
           description:
             The date and time that this user first signed in or was invited
             as a guest.
+          readOnly: true
+          format: date-time
+        updatedAt:
+          type: string
+          description: The date and time that this user was last updated.
+          readOnly: true
+          format: date-time
+        deletedAt:
+          type: string
+          nullable: true
+          description: The date and time that this user was deleted, if applicable.
           readOnly: true
           format: date-time
     Invite:
@@ -6836,13 +7089,35 @@ components:
           description: Identifier for the associated user.
           readOnly: true
           format: uuid
-        collectionId:
+        documentId:
           type: string
-          description: Identifier for the associated collection.
+          description: Identifier for the associated document, if any.
           readOnly: true
           format: uuid
+          nullable: true
+        collectionId:
+          type: string
+          description: Identifier for the associated collection, if any.
+          readOnly: true
+          format: uuid
+          nullable: true
         permission:
           "$ref": "#/components/schemas/Permission"
+        createdById:
+          type: string
+          description: Identifier for the user who created this membership.
+          readOnly: true
+          format: uuid
+        sourceId:
+          type: string
+          description: Identifier for the membership this one was inherited from, if any.
+          readOnly: true
+          format: uuid
+          nullable: true
+        index:
+          type: string
+          description: The position of the collection in the user's sidebar.
+          nullable: true
     SearchResult:
       type: object
       properties:
@@ -6910,13 +7185,26 @@ components:
           description: Identifier for the associated group.
           readOnly: true
           format: uuid
-        userId:
+        documentId:
           type: string
-          description: Identifier for the associated user.
+          description: Identifier for the associated document, if any.
           readOnly: true
           format: uuid
-        user:
-          "$ref": "#/components/schemas/User"
+          nullable: true
+        collectionId:
+          type: string
+          description: Identifier for the associated collection, if any.
+          readOnly: true
+          format: uuid
+          nullable: true
+        permission:
+          "$ref": "#/components/schemas/Permission"
+        sourceId:
+          type: string
+          description: Identifier for the membership this one was inherited from, if any.
+          readOnly: true
+          format: uuid
+          nullable: true
     CollectionGroupMembership:
       type: object
       properties:
@@ -6929,13 +7217,26 @@ components:
           description: Identifier for the associated group.
           readOnly: true
           format: uuid
-        collectionId:
+        documentId:
           type: string
-          description: Identifier for the associated collection.
+          description: Identifier for the associated document, if any.
           readOnly: true
           format: uuid
+          nullable: true
+        collectionId:
+          type: string
+          description: Identifier for the associated collection, if any.
+          readOnly: true
+          format: uuid
+          nullable: true
         permission:
           "$ref": "#/components/schemas/Permission"
+        sourceId:
+          type: string
+          description: Identifier for the membership this one was inherited from, if any.
+          readOnly: true
+          format: uuid
+          nullable: true
     Template:
       type: object
       properties:
@@ -6996,6 +7297,7 @@ components:
           nullable: true
         publishedAt:
           type: string
+          nullable: true
           description: The date and time that the template was published.
           readOnly: true
           format: date-time
@@ -7025,6 +7327,11 @@ components:
           type: number
           description: The number of times the user has viewed the document.
           example: 22
+          readOnly: true
+        userId:
+          type: string
+          format: uuid
+          description: Identifier of the user who viewed the document.
           readOnly: true
         user:
           "$ref": "#/components/schemas/User"

--- a/spec3.yml
+++ b/spec3.yml
@@ -6380,6 +6380,17 @@ components:
           enum:
             - import
             - export
+        format:
+          type: string
+          description: The file format of the resulting file.
+          example: outline-markdown
+          readOnly: true
+        name:
+          type: string
+          description: >-
+            The name of the file operation, derived from the collection name,
+            document title, or file name.
+          readOnly: true
         state:
           type: string
           description: The state of the file operation.
@@ -6391,20 +6402,44 @@ components:
             - complete
             - error
             - expired
-        collection:
-          allOf:
-            - nullable: true
-            - "$ref": "#/components/schemas/Collection"
+        error:
+          type: string
+          nullable: true
+          description: An error message if the file operation failed.
+          readOnly: true
+        size:
+          type: string
+          description: >-
+            The size of the resulting file in bytes. Returned as a string as the
+            value may exceed the safe integer range.
+          readOnly: true
+          example: "2048"
+        collectionId:
+          type: string
+          nullable: true
+          description: >-
+            Identifier for the associated collection, if the file operation is
+            scoped to a single collection.
+          readOnly: true
+          format: uuid
+        documentId:
+          type: string
+          nullable: true
+          description: >-
+            Identifier for the associated document, if the file operation is
+            scoped to a single document.
+          readOnly: true
+          format: uuid
         user:
           "$ref": "#/components/schemas/User"
-        size:
-          type: number
-          description: The size of the resulting file in bytes
-          readOnly: true
-          example: 2048
         createdAt:
           type: string
           description: The date and time that this object was created
+          readOnly: true
+          format: date-time
+        updatedAt:
+          type: string
+          description: The date and time that this object was last changed
           readOnly: true
           format: date-time
     Group:


### PR DESCRIPTION
## Summary

A reported validation error (`Input should be a valid number [type=float_type, input_value='0', input_type=str]`) traced back to the `FileOperation.size` field being documented as a `number` while the API actually serializes it as a **string** — `size` is a `BIGINT` column, which Sequelize serializes as a string to avoid JavaScript safe-integer precision loss.

Since that class of mismatch could exist elsewhere, every response schema with a backing presenter was audited against the [Outline source presenters](https://github.com/outline/outline/tree/main/server/presenters) and corrected so the documented output shape matches what the API actually returns.

## Changes

**Type correction (the original bug + its sibling)**
- `FileOperation.size`: `number` → `string` (BIGINT). Also added the other presenter fields: `format`, `name`, `error`, `collectionId`, `documentId`, `updatedAt`; replaced the embedded `collection` object with `collectionId`.
- `Attachment.size`: `number` → `string` (BIGINT). Added `userId`; marked `documentId` nullable.

**Fields that were documented but are not returned (removed)**
- `Team.collaborativeEditing`
- `Document.pinned`
- `Comment.updatedBy`
- `Star.documentUrl`
- `GroupMembership.userId` / `user`

**Fields returned by presenters but missing (added)**
- `User`: `color`, `timezone`, `updatedAt`, `deletedAt`
- `Team`: `description`, `memberTeamCreate`, `passkeysEnabled`, `domain`, `preferences`, `guidanceMCP`
- `Collection`: `url`, `commenting`, `templateManagement`, `sourceMetadata`, `data`
- `Document`: `url`, `color`, `data`, `tasks`; renamed `emoji` → `icon`; replaced embedded `collaborators` with `collaboratorIds`
- `Comment`: `createdById`, `resolvedAt`, `resolvedBy`, `resolvedById`, `reactions`
- `Revision`: `name`, `data`, `icon`, `color`, `collaborators`, `createdById`, `deletedAt`
- `Share`: `sourceTitle`, `sourcePath`, `documentId`, `collectionId`, `urlId`, `domain`, `allowIndexing`, `showLastUpdated`, `showTOC`, `views`
- `Star`: `updatedAt`
- `Event`: `userId`, `changes`
- `Group`: `description`, `externalId`, `disableMentions`, `externalGroup`
- `OAuthClient`: `clientType`, `lastActiveAt`
- `OAuthAuthentication`: `oauthClient`, `createdAt`
- `Membership`: `documentId`, `createdById`, `sourceId`, `index`
- `GroupMembership`: `documentId`, `collectionId`, `permission`, `sourceId`
- `CollectionGroupMembership`: `documentId`, `sourceId`
- `View`: `userId`

**Nullability corrections** applied to fields the models declare as nullable across `User`, `Collection`, `Document`, `Template`, `Share`, `Star`, `OAuthClient`, `Membership`, `GroupMembership`, and `CollectionGroupMembership`.

## Validation

- `spectral lint --fail-severity=error` passes (no errors).
- Operation-ID validation passes.
- `spec3.json` regenerated from the YAML (same script the pre-commit hook runs).
