### PR TITLE
Document data parameter on collections.create and collections.update

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -910,8 +910,12 @@
                   },
                   "description": {
                     "type": "string",
-                    "description": "A brief description of the collection, markdown supported.",
+                    "description": "A brief description of the collection, markdown supported. Only one of `description` or `data` may be provided.",
                     "example": "HR documentation is confidential and should be handled with care."
+                  },
+                  "data": {
+                    "type": "object",
+                    "description": "The collection description as a rich-text ProseMirror JSON document. Only one of `description` or `data` may be provided."
                   },
                   "permission": {
                     "$ref": "#/components/schemas/Permission"
@@ -999,8 +1003,12 @@
                   },
                   "description": {
                     "type": "string",
-                    "description": "A brief description of the collection, markdown supported.",
+                    "description": "A brief description of the collection, markdown supported. Only one of `description` or `data` may be provided.",
                     "example": "HR documentation is confidential and should be handled with care."
+                  },
+                  "data": {
+                    "type": "object",
+                    "description": "The collection description as a rich-text ProseMirror JSON document. Only one of `description` or `data` may be provided."
                   },
                   "permission": {
                     "$ref": "#/components/schemas/Permission"

--- a/spec3.yml
+++ b/spec3.yml
@@ -808,8 +808,11 @@ paths:
                   example: Human Resources
                 description:
                   type: string
-                  description: A brief description of the collection, markdown supported.
+                  description: A brief description of the collection, markdown supported. Only one of `description` or `data` may be provided.
                   example: HR documentation is confidential and should be handled with care.
+                data:
+                  type: object
+                  description: The collection description as a rich-text ProseMirror JSON document. Only one of `description` or `data` may be provided.
                 permission:
                   "$ref": "#/components/schemas/Permission"
                 icon:
@@ -868,8 +871,11 @@ paths:
                   example: Human Resources
                 description:
                   type: string
-                  description: A brief description of the collection, markdown supported.
+                  description: A brief description of the collection, markdown supported. Only one of `description` or `data` may be provided.
                   example: HR documentation is confidential and should be handled with care.
+                data:
+                  type: object
+                  description: The collection description as a rich-text ProseMirror JSON document. Only one of `description` or `data` may be provided.
                 permission:
                   "$ref": "#/components/schemas/Permission"
                 icon:


### PR DESCRIPTION
## Summary

Reflects [outline/outline#12648](https://github.com/outline/outline/pull/12648), which added validation rejecting requests that include both `description` and `data` on the collection create/update endpoints.

- Documents the previously-undocumented `data` parameter (rich-text ProseMirror JSON) on `/collections.create` and `/collections.update`.
- Notes the new mutual exclusivity: only one of `description` or `data` may be provided.

The other PRs merged in the last day (#12668 editor math/media, #12667 markdown serialization speed, #12660 multiplayer cursor selection, #12669 drop dead `collaborativeEditing` column, #12650 emoji reaction shorthand) do not affect the public API surface — `collaborativeEditing` is not exposed in the spec.

Only `spec3.yml` is updated; `spec3.json` will be regenerated by the pre-commit hook.

## Test plan
- [ ] Verify the spec renders correctly in the Swagger editor.
- [ ] Confirm `spec3.json` is regenerated on merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_0167jiB6HjEYpQ4cpm8r2dCW)_