### PR TITLE
Omit data and text from revisions.list response

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -6590,7 +6590,7 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "$ref": "#/components/schemas/Revision"
+                      "$ref": "#/components/schemas/RevisionDetail"
                     }
                   }
                 }
@@ -6619,7 +6619,7 @@
           "Revisions"
         ],
         "summary": "List all revisions",
-        "description": "List all revisions for a specific document. Revisions represent historical snapshots of a document's content and can be used to track changes over time.",
+        "description": "List all revisions for a specific document. Revisions represent historical snapshots of a document's content and can be used to track changes over time. The `data` and `text` fields are omitted from listed revisions for performance; use `revisions.info` to retrieve the full content of a specific revision.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9636,16 +9636,6 @@
             "description": "The name of the revision, if any.",
             "readOnly": true
           },
-          "data": {
-            "type": "object",
-            "description": "The body of the revision as a Prosemirror document.",
-            "readOnly": true
-          },
-          "text": {
-            "type": "string",
-            "description": "Body of the document, may contain markdown formatting",
-            "readOnly": true
-          },
           "icon": {
             "type": "string",
             "nullable": true,
@@ -9687,6 +9677,28 @@
             "readOnly": true
           }
         }
+      },
+      "RevisionDetail": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Revision"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "The body of the revision as a Prosemirror document.",
+                "readOnly": true
+              },
+              "text": {
+                "type": "string",
+                "description": "Body of the document, may contain markdown formatting",
+                "readOnly": true
+              }
+            }
+          }
+        ]
       },
       "Share": {
         "type": "object",

--- a/spec3.yml
+++ b/spec3.yml
@@ -4623,7 +4623,7 @@ paths:
                 type: object
                 properties:
                   data:
-                    "$ref": "#/components/schemas/Revision"
+                    "$ref": "#/components/schemas/RevisionDetail"
         "401":
           "$ref": "#/components/responses/Unauthenticated"
         "403":
@@ -4638,7 +4638,7 @@ paths:
       tags:
         - Revisions
       summary: List all revisions
-      description: List all revisions for a specific document. Revisions represent historical snapshots of a document's content and can be used to track changes over time.
+      description: List all revisions for a specific document. Revisions represent historical snapshots of a document's content and can be used to track changes over time. The `data` and `text` fields are omitted from listed revisions for performance; use `revisions.info` to retrieve the full content of a specific revision.
       requestBody:
         content:
           application/json:
@@ -6764,14 +6764,6 @@ components:
           nullable: true
           description: The name of the revision, if any.
           readOnly: true
-        data:
-          type: object
-          description: The body of the revision as a Prosemirror document.
-          readOnly: true
-        text:
-          type: string
-          description: Body of the document, may contain markdown formatting
-          readOnly: true
         icon:
           type: string
           nullable: true
@@ -6804,6 +6796,19 @@ components:
           nullable: true
           description: Date and time when this revision was deleted, if applicable.
           readOnly: true
+    RevisionDetail:
+      allOf:
+        - "$ref": "#/components/schemas/Revision"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: The body of the revision as a Prosemirror document.
+              readOnly: true
+            text:
+              type: string
+              description: Body of the document, may contain markdown formatting
+              readOnly: true
     Share:
       type: object
       properties:


### PR DESCRIPTION
Documents the change in outline/outline#12822: the `/revisions.list` endpoint no longer returns the `data` and `text` fields for each revision (they were dropped to reduce response size). Full revision content remains available via `/revisions.info`.

## Changes

- Removed `data` and `text` from the `Revision` schema — it now represents a listed revision.
- Added a new `RevisionDetail` schema that extends `Revision` with the `data` and `text` fields.
- Updated `/revisions.info` to respond with `RevisionDetail`.
- Added a note to the `/revisions.list` description clarifying the omission and pointing to `/revisions.info` for full content.

---
_Generated by [Claude Code](https://claude.ai/code/session_011NFfsYpzGuw1zvbQUJUu6g)_