### PR TITLE
Document mcp source on SearchResult

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -10149,7 +10149,8 @@
             "readOnly": true,
             "enum": [
               "api",
-              "app"
+              "app",
+              "mcp"
             ]
           },
           "createdAt": {

--- a/spec3.yml
+++ b/spec3.yml
@@ -7206,6 +7206,7 @@ components:
           enum:
             - api
             - app
+            - mcp
         createdAt:
           type: string
           description: The date and time that this object was created


### PR DESCRIPTION
Reflects outline/outline#13011, which introduces the `SearchQuerySource` enum and adds `mcp` as a valid source value. Search queries recorded when the MCP `list_documents` tool is called will now surface as `source: "mcp"` on the `SearchResult` schema.

Adds `mcp` to the `SearchResult.source` enum in `spec3.yml`; `spec3.json` is regenerated from the YAML.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWBwKr12ChN7t5fA9ocoU3)_