### PR TITLE
Document text max length and share createdBy visibility

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -3524,6 +3524,7 @@
                   },
                   "text": {
                     "type": "string",
+                    "maxLength": 1536000,
                     "description": "The body of the document in markdown"
                   },
                   "icon": {
@@ -3664,6 +3665,7 @@
                   },
                   "text": {
                     "type": "string",
+                    "maxLength": 1536000,
                     "description": "The body of the document in markdown."
                   },
                   "icon": {
@@ -9818,7 +9820,14 @@
             "readOnly": true
           },
           "createdBy": {
-            "$ref": "#/components/schemas/User"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/User"
+              }
+            ],
+            "nullable": true,
+            "description": "The user that created the share. Only returned to viewers with access to read the share; omitted from responses to unauthenticated viewers of a published share, and when the creating user has been deleted.",
+            "readOnly": true
           },
           "updatedAt": {
             "type": "string",

--- a/spec3.yml
+++ b/spec3.yml
@@ -2582,6 +2582,7 @@ paths:
                   example: Welcome to Acme Inc
                 text:
                   type: string
+                  maxLength: 1536000
                   description: The body of the document in markdown
                 icon:
                   type: string
@@ -2680,6 +2681,7 @@ paths:
                   description: The title of the document.
                 text:
                   type: string
+                  maxLength: 1536000
                   description: The body of the document in markdown.
                 icon:
                   type: string
@@ -6913,7 +6915,14 @@ components:
           description: Date and time when this share was created
           readOnly: true
         createdBy:
-          "$ref": "#/components/schemas/User"
+          allOf:
+            - "$ref": "#/components/schemas/User"
+          nullable: true
+          description: The user that created the share. Only returned to viewers
+            with access to read the share; omitted from responses to
+            unauthenticated viewers of a published share, and when the creating
+            user has been deleted.
+          readOnly: true
         updatedAt:
           type: string
           format: date-time


### PR DESCRIPTION
Two changes pulled in from recent server-side updates in `outline/outline`:

- **`documents.create` / `documents.update`**: add `maxLength: 1536000` (~1.5 MB) to the `text` parameter, matching the newly-enforced Zod limit on incoming document bodies (outline/outline#13143).
- **`Share.createdBy`**: mark the field nullable and note that it is only returned to viewers with read access — it is omitted from responses to unauthenticated viewers of a published share, and when the creating user has been deleted (outline/outline#13144).

`spec3.json` is regenerated from `spec3.yml` by the pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_012xinMidCL3JwQUWgfDGewc)_