### PR TITLE
Document collections.duplicate endpoint

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -1095,6 +1095,77 @@
         "operationId": "collectionsUpdate"
       }
     },
+    "/collections.duplicate": {
+      "post": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Duplicate a collection",
+        "description": "Duplicate an existing collection along with its documents into a new collection.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Identifier for the collection to duplicate",
+                    "format": "uuid"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "New name for the duplicated collection"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Collection"
+                    },
+                    "policies": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Policy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Validation"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        },
+        "operationId": "collectionsDuplicate"
+      }
+    },
     "/collections.add_user": {
       "post": {
         "tags": [

--- a/spec3.yml
+++ b/spec3.yml
@@ -941,6 +941,52 @@ paths:
         "429":
           "$ref": "#/components/responses/RateLimited"
       operationId: collectionsUpdate
+  "/collections.duplicate":
+    post:
+      tags:
+        - Collections
+      summary: Duplicate a collection
+      description: Duplicate an existing collection along with its documents into a new collection.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Identifier for the collection to duplicate
+                  format: uuid
+                name:
+                  type: string
+                  description: New name for the duplicated collection
+              required:
+                - id
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/Collection"
+                  policies:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Policy"
+        "400":
+          "$ref": "#/components/responses/Validation"
+        "401":
+          "$ref": "#/components/responses/Unauthenticated"
+        "403":
+          "$ref": "#/components/responses/Unauthorized"
+        "404":
+          "$ref": "#/components/responses/NotFound"
+        "429":
+          "$ref": "#/components/responses/RateLimited"
+      operationId: collectionsDuplicate
   "/collections.add_user":
     post:
       tags:


### PR DESCRIPTION
Adds YAML documentation for the new `POST /collections.duplicate` endpoint introduced in [outline/outline#13197](https://github.com/outline/outline/pull/13197), which duplicates an existing collection along with its documents.

### Request body
- `id` (uuid, required) — collection to duplicate
- `name` (string, optional) — new name for the duplicated collection

### Response
- `data` — the newly created `Collection`
- `policies` — user policies for the duplicated collection

The `spec3.json` was regenerated by the pre-commit hook.

### Other recent PRs reviewed
The following merged PRs from the last day were reviewed and require no YAML changes:

- outline/outline#13199 — UI-only (sidebar depth)
- outline/outline#13198 — internal authorization refactor on `documents.duplicate`, request/response shape unchanged
- outline/outline#13189 — internal URL matching for `urls.unfurl`, request/response shape unchanged
- outline/outline#13140, #13117, #13195, #13193, #13196, #13194, #13192, #13188, #13187 — UI, performance, infra, or a11y changes with no API surface impact

---
_Generated by [Claude Code](https://claude.ai/code/session_018uJFsZBnF3akRtKKN5SQbK)_