### PR TITLE
Document new collections.duplicate endpoint

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -999,6 +999,77 @@
         "operationId": "collectionsCreate"
       }
     },
+    "/collections.duplicate": {
+      "post": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Duplicate a collection",
+        "description": "Duplicate an existing collection along with its published documents. The\noriginal collection's settings – icon, color, permission, sharing, and\nsorting – are preserved on the copy. Draft and archived documents are\nnot duplicated. Document duplication runs asynchronously in the\nbackground, so the copy may initially be returned before all of its\ndocuments have been created.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique identifier for the collection to duplicate.",
+                    "format": "uuid"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "An optional name for the new collection. If omitted, the original collection's name is reused."
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Collection"
+                    },
+                    "policies": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Policy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Validation"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        },
+        "operationId": "collectionsDuplicate"
+      }
+    },
     "/collections.update": {
       "post": {
         "tags": [

--- a/spec3.yml
+++ b/spec3.yml
@@ -876,6 +876,58 @@ paths:
         "429":
           "$ref": "#/components/responses/RateLimited"
       operationId: collectionsCreate
+  "/collections.duplicate":
+    post:
+      tags:
+        - Collections
+      summary: Duplicate a collection
+      description: |
+        Duplicate an existing collection along with its published documents. The
+        original collection's settings – icon, color, permission, sharing, and
+        sorting – are preserved on the copy. Draft and archived documents are
+        not duplicated. Document duplication runs asynchronously in the
+        background, so the copy may initially be returned before all of its
+        documents have been created.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Unique identifier for the collection to duplicate.
+                  format: uuid
+                name:
+                  type: string
+                  description: An optional name for the new collection. If omitted, the original collection's name is reused.
+              required:
+                - id
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/Collection"
+                  policies:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Policy"
+        "400":
+          "$ref": "#/components/responses/Validation"
+        "401":
+          "$ref": "#/components/responses/Unauthenticated"
+        "403":
+          "$ref": "#/components/responses/Unauthorized"
+        "404":
+          "$ref": "#/components/responses/NotFound"
+        "429":
+          "$ref": "#/components/responses/RateLimited"
+      operationId: collectionsDuplicate
   "/collections.update":
     post:
       tags:


### PR DESCRIPTION
Adds documentation for `POST /collections.duplicate`, a new public endpoint added in [outline/outline#13197](https://github.com/outline/outline/pull/13197).

The endpoint duplicates an existing collection along with its published documents, preserving the original collection's settings (icon, color, permission, sharing, sorting). Drafts and archived documents are not duplicated. Document duplication runs asynchronously in the background, so the copy may initially be returned before all of its documents have been created.

- Input: `id` (uuid, required), `name` (string, optional – defaults to the original name).
- Response: `{ data: Collection, policies: Policy[] }`, matching the shape of `collections.create` / `collections.update`.

Other PRs merged in the last day (13117, 13140, 13189, 13194, 13195, 13198, 13199, 13200, 13202, 13203) were reviewed and either don't affect the public API surface or only change internal behavior/authorization without altering the input schema or response shape.

`spec3.json` is regenerated from `spec3.yml` by the pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErSUgEtHbaL67e4wbVfL8f)_