### PR TITLE
Document additional supported import formats

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -2731,7 +2731,7 @@
                 "properties": {
                   "file": {
                     "type": "object",
-                    "description": "Plain text, markdown, docx, csv, tsv, and html format are supported."
+                    "description": "Plain text, markdown, docx, csv, tsv, html, mhtml (or mht) web pages, and eml email messages are supported."
                   },
                   "collectionId": {
                     "type": "string",

--- a/spec3.yml
+++ b/spec3.yml
@@ -2034,8 +2034,8 @@ paths:
               properties:
                 file:
                   type: object
-                  description: Plain text, markdown, docx, csv, tsv, and html format
-                    are supported.
+                  description: Plain text, markdown, docx, csv, tsv, html, mhtml
+                    (or mht) web pages, and eml email messages are supported.
                 collectionId:
                   type: string
                   format: uuid


### PR DESCRIPTION
Updates the `/documents.import` file description to reflect the additional formats added in outline/outline#13229:

- `.mhtml` / `.mht` — MHTML web pages
- `.eml` — email messages

Other pull requests merged in the last day were either UI-only, i18n, CI, or internal backend fixes with no observable change to the public API input schema or output shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQ7usEAWYUyXHWJrfLAqKD)_