### PR TITLE
Document TextBundle format on /documents.export

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -2801,7 +2801,7 @@
           "Documents"
         ],
         "summary": "Export a document.",
-        "description": "Export a document in Markdown, HTML, or PDF format. The response format is determined by the Accept header. Optionally include child documents in the export as a zip file.",
+        "description": "Export a document in Markdown, HTML, PDF, or TextBundle format. The response format is determined by the Accept header (`text/markdown`, `text/html`, `application/pdf`, or `application/x-textbundle`). Optionally include child documents in the export as a zip file.",
         "requestBody": {
           "content": {
             "application/json": {

--- a/spec3.yml
+++ b/spec3.yml
@@ -2079,7 +2079,7 @@ paths:
       tags:
         - Documents
       summary: Export a document.
-      description: Export a document in Markdown, HTML, or PDF format. The response format is determined by the Accept header. Optionally include child documents in the export as a zip file.
+      description: Export a document in Markdown, HTML, PDF, or TextBundle format. The response format is determined by the Accept header (`text/markdown`, `text/html`, `application/pdf`, or `application/x-textbundle`). Optionally include child documents in the export as a zip file.
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Updates the `/documents.export` endpoint description to reflect the new TextBundle (`.textpack`) export format added in [outline/outline#13235](https://github.com/outline/outline/pull/13235).

The endpoint now supports `application/x-textbundle` as an `Accept` header value in addition to the existing `text/markdown`, `text/html`, and `application/pdf` values.

Only the YAML is updated; the JSON is regenerated by the pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzdTZjVTAtwCcpbjG7kjC7)_