### PR TITLE
Document event authType and textbundle/textpack import support

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -2731,7 +2731,7 @@
                 "properties": {
                   "file": {
                     "type": "object",
-                    "description": "Plain text, markdown, docx, csv, tsv, html, mhtml (or mht) web pages, and eml email messages are supported."
+                    "description": "Plain text, markdown, docx, csv, tsv, html, mhtml (or mht) web pages, eml email messages, and textbundle/textpack bundles are supported."
                   },
                   "collectionId": {
                     "type": "string",
@@ -9315,6 +9315,18 @@
             "type": "string",
             "description": "The user that performed the action.",
             "format": "uuid",
+            "readOnly": true
+          },
+          "authType": {
+            "type": "string",
+            "description": "The authentication method used to perform the action.",
+            "enum": [
+              "api",
+              "app",
+              "mcp",
+              "oauth"
+            ],
+            "nullable": true,
             "readOnly": true
           },
           "actorIpAddress": {

--- a/spec3.yml
+++ b/spec3.yml
@@ -2035,7 +2035,8 @@ paths:
                 file:
                   type: object
                   description: Plain text, markdown, docx, csv, tsv, html, mhtml
-                    (or mht) web pages, and eml email messages are supported.
+                    (or mht) web pages, eml email messages, and textbundle/textpack
+                    bundles are supported.
                 collectionId:
                   type: string
                   format: uuid
@@ -6499,6 +6500,16 @@ components:
           type: string
           description: The user that performed the action.
           format: uuid
+          readOnly: true
+        authType:
+          type: string
+          description: The authentication method used to perform the action.
+          enum:
+            - api
+            - app
+            - mcp
+            - oauth
+          nullable: true
           readOnly: true
         actorIpAddress:
           type: string


### PR DESCRIPTION
Documents two API changes merged into outline/outline in the last day.

## Changes

- **`Event.authType`** (outline/outline#13294) — the event presenter now returns an `authType` field indicating which authentication method was used to perform the action (`api`, `app`, `mcp`, or `oauth`). Added to the `Event` schema as a nullable readOnly string enum. Surfaces on `/events.list` and anywhere else `Event` is returned.
- **`/documents.import`** (outline/outline#13235) — textbundle/textpack (`.textpack`) files are now accepted alongside the existing formats. Updated the `file` field description.

The `/documents.export` endpoint description already mentioned TextBundle from a prior commit, so no change there. Other API-adjacent PRs from the window were either behavior-only fixes (e.g. #13289 auto-generating collaborative state so `/comments.create` no longer rejects inline comments on API-created documents), performance work, or internal refactors — nothing needing a schema shape change.

Only `spec3.yml` was edited; `spec3.json` will be regenerated by the pre-commit hooks.

---
_Generated by [Claude Code](https://claude.ai/code/session_0132HGeRM2BPJX6eTUL5CGe4)_