### PR TITLE
Document revision sourceMetadata authType and PDF import support

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -2731,7 +2731,7 @@
                 "properties": {
                   "file": {
                     "type": "object",
-                    "description": "Plain text, markdown, docx, csv, tsv, html, mhtml (or mht) web pages, eml email messages, and textbundle/textpack bundles are supported."
+                    "description": "Plain text, markdown, docx, pdf, csv, tsv, html, mhtml (or mht) web pages, eml email messages, and textbundle/textpack bundles are supported."
                   },
                   "collectionId": {
                     "type": "string",
@@ -9764,6 +9764,26 @@
             "nullable": true,
             "description": "Date and time when this revision was deleted, if applicable.",
             "readOnly": true
+          },
+          "sourceMetadata": {
+            "type": "object",
+            "nullable": true,
+            "description": "Metadata about how the revision was created, if any.",
+            "readOnly": true,
+            "properties": {
+              "authType": {
+                "type": "string",
+                "description": "The authentication method used to create the revision.",
+                "enum": [
+                  "api",
+                  "app",
+                  "mcp",
+                  "oauth"
+                ],
+                "nullable": true,
+                "readOnly": true
+              }
+            }
           }
         }
       },

--- a/spec3.yml
+++ b/spec3.yml
@@ -2034,9 +2034,9 @@ paths:
               properties:
                 file:
                   type: object
-                  description: Plain text, markdown, docx, csv, tsv, html, mhtml
-                    (or mht) web pages, eml email messages, and textbundle/textpack
-                    bundles are supported.
+                  description: Plain text, markdown, docx, pdf, csv, tsv, html,
+                    mhtml (or mht) web pages, eml email messages, and
+                    textbundle/textpack bundles are supported.
                 collectionId:
                   type: string
                   format: uuid
@@ -6864,6 +6864,22 @@ components:
           nullable: true
           description: Date and time when this revision was deleted, if applicable.
           readOnly: true
+        sourceMetadata:
+          type: object
+          nullable: true
+          description: Metadata about how the revision was created, if any.
+          readOnly: true
+          properties:
+            authType:
+              type: string
+              description: The authentication method used to create the revision.
+              enum:
+                - api
+                - app
+                - mcp
+                - oauth
+              nullable: true
+              readOnly: true
     RevisionDetail:
       allOf:
         - "$ref": "#/components/schemas/Revision"


### PR DESCRIPTION
- Add `sourceMetadata.authType` to the `Revision` schema, indicating whether the revision was created via `api`, `app`, `mcp`, or `oauth` authentication (outline/outline#13312)
- Note `pdf` files as a supported `/documents.import` format (outline/outline#13302)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKQcsgkwr7T3RXdHw3vb2k)_