### PR TITLE
Document invitedBy on User and sourceMetadata.authType on Revision

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -9764,6 +9764,26 @@
             "nullable": true,
             "description": "Date and time when this revision was deleted, if applicable.",
             "readOnly": true
+          },
+          "sourceMetadata": {
+            "type": "object",
+            "nullable": true,
+            "description": "Metadata about the source of this revision, if any.",
+            "readOnly": true,
+            "properties": {
+              "authType": {
+                "type": "string",
+                "nullable": true,
+                "description": "The authentication method used when this revision was created.",
+                "enum": [
+                  "api",
+                  "app",
+                  "mcp",
+                  "oauth"
+                ],
+                "readOnly": true
+              }
+            }
           }
         }
       },
@@ -10129,6 +10149,16 @@
             "description": "The date and time that this user was deleted, if applicable.",
             "readOnly": true,
             "format": "date-time"
+          },
+          "invitedBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/User"
+              }
+            ],
+            "nullable": true,
+            "description": "The user who invited this user, if any. Only returned to admins.",
+            "readOnly": true
           }
         }
       },

--- a/spec3.yml
+++ b/spec3.yml
@@ -6864,6 +6864,22 @@ components:
           nullable: true
           description: Date and time when this revision was deleted, if applicable.
           readOnly: true
+        sourceMetadata:
+          type: object
+          nullable: true
+          description: Metadata about the source of this revision, if any.
+          readOnly: true
+          properties:
+            authType:
+              type: string
+              nullable: true
+              description: The authentication method used when this revision was created.
+              enum:
+                - api
+                - app
+                - mcp
+                - oauth
+              readOnly: true
     RevisionDetail:
       allOf:
         - "$ref": "#/components/schemas/Revision"
@@ -7190,6 +7206,13 @@ components:
           description: The date and time that this user was deleted, if applicable.
           readOnly: true
           format: date-time
+        invitedBy:
+          allOf:
+            - "$ref": "#/components/schemas/User"
+          nullable: true
+          description:
+            The user who invited this user, if any. Only returned to admins.
+          readOnly: true
     Invite:
       type: object
       properties:


### PR DESCRIPTION
Reflects two changes recently merged to `outline/outline`:

- [outline/outline#13325](https://github.com/outline/outline/pull/13325) — User responses now include an `invitedBy` user object. It is eager-loaded on `users.list` and only returned to admins.
- [outline/outline#13312](https://github.com/outline/outline/pull/13312) — Revision responses now include a `sourceMetadata` object with an `authType` field capturing which authentication method (`api`, `app`, `mcp`, `oauth`) created the revision.

Only `spec3.yml` was edited by hand; `spec3.json` was regenerated by the pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8M2DkrMHkkH9oAo5kP4dP)_