### PR TITLE
Document invitedBy field on User schema

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -10129,6 +10129,16 @@
             "description": "The date and time that this user was deleted, if applicable.",
             "readOnly": true,
             "format": "date-time"
+          },
+          "invitedBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/User"
+              }
+            ],
+            "nullable": true,
+            "description": "The user that invited this user, if they were invited. Only included in responses to admin users.",
+            "readOnly": true
           }
         }
       },

--- a/spec3.yml
+++ b/spec3.yml
@@ -7190,6 +7190,13 @@ components:
           description: The date and time that this user was deleted, if applicable.
           readOnly: true
           format: date-time
+        invitedBy:
+          allOf:
+            - "$ref": "#/components/schemas/User"
+          nullable: true
+          description: The user that invited this user, if they were invited. Only
+            included in responses to admin users.
+          readOnly: true
     Invite:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Adds a new `invitedBy` property to the `User` schema, mirroring the field added to the `users.list` response in [outline/outline#13325](https://github.com/outline/outline/pull/13325). The field is a nested `User` object identifying who invited the user, and is only populated in responses to admin viewers.

## Recent PRs Reviewed

Reviewed all pull requests merged in outline/outline over the last day (2026-08-07 → 2026-08-08). Most were internal fixes with no public API impact:

- #13345 (templates `data`) — bug fix only, existing schema already documents `data` as non-nullable
- #13344, #13343, #13342, #13334, #13335, #13336, #13341, #13333, #13329, #13331 — internal implementation details, no public schema changes
- #13332 (`auth.info` `collaborationToken`) — field was never documented in the spec (only issued to APP-type sessions)
- #13330 (`suggestions.mention` guest scoping) — endpoint not documented in the spec
- #13328 — internal rate-limiting change
- #13326, #13324 — UI-only
- **#13325** — adds `invitedBy` to `users.list` response → documented in this PR

## Test plan

- [x] `yarn validate` passes
- [x] `spec3.json` regenerated via pre-commit hook

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdovjbPpWgw1E2CFagLB4o)_