### PR TITLE
Document draft templates and publish parameter

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -8078,13 +8078,12 @@
                   },
                   "title": {
                     "type": "string",
-                    "description": "The title of the template.",
-                    "minLength": 1,
+                    "description": "The title of the template. Required when publishing.",
                     "maxLength": 255
                   },
                   "data": {
                     "type": "object",
-                    "description": "The body of the template as a Prosemirror document."
+                    "description": "The body of the template as a Prosemirror document. Required when publishing."
                   },
                   "icon": {
                     "type": "string",
@@ -8101,12 +8100,13 @@
                     "type": "string",
                     "format": "uuid",
                     "description": "Identifier for the collection to which the template belongs."
+                  },
+                  "publish": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether the template is available to other members. Set to false to create a draft that is only visible to its creator."
                   }
-                },
-                "required": [
-                  "title",
-                  "data"
-                ]
+                }
               }
             }
           }
@@ -8338,6 +8338,10 @@
                     "format": "uuid",
                     "description": "Identifier for the collection to which the template belongs. Set to null for a workspace-wide template.",
                     "nullable": true
+                  },
+                  "publish": {
+                    "type": "boolean",
+                    "description": "Set to true to publish a draft template so it becomes available to other members."
                   }
                 },
                 "required": [

--- a/spec3.yml
+++ b/spec3.yml
@@ -5603,12 +5603,11 @@ paths:
                   description: Optionally provide a specific UUID for the template.
                 title:
                   type: string
-                  description: The title of the template.
-                  minLength: 1
+                  description: The title of the template. Required when publishing.
                   maxLength: 255
                 data:
                   type: object
-                  description: The body of the template as a Prosemirror document.
+                  description: The body of the template as a Prosemirror document. Required when publishing.
                 icon:
                   type: string
                   description: An emoji to use as the template icon.
@@ -5622,9 +5621,10 @@ paths:
                   type: string
                   format: uuid
                   description: Identifier for the collection to which the template belongs.
-              required:
-                - title
-                - data
+                publish:
+                  type: boolean
+                  default: true
+                  description: Whether the template is available to other members. Set to false to create a draft that is only visible to its creator.
       responses:
         "200":
           description: OK
@@ -5775,6 +5775,9 @@ paths:
                   format: uuid
                   description: Identifier for the collection to which the template belongs. Set to null for a workspace-wide template.
                   nullable: true
+                publish:
+                  type: boolean
+                  description: Set to true to publish a draft template so it becomes available to other members.
               required:
                 - id
       responses:


### PR DESCRIPTION
Reflects the persist-template-drafts changes in [outline/outline#13357](https://github.com/outline/outline/pull/13357):

- `/templates.create`: `title` and `data` are no longer required — a template can now be created as an empty draft. Both fields remain required at the API level when the request publishes (the default). A new `publish` boolean (defaults to `true`) controls whether the template is available to other members immediately, or created as a draft that only its creator can see.
- `/templates.update`: adds an optional `publish` boolean; setting it to `true` on a draft template publishes it.

Only the YAML is updated here — `spec3.json` is regenerated by the pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_015pmLXq3inZ9NWjBfFWhoGt)_