### PR TITLE
Document template draft persistence

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -8064,7 +8064,7 @@
           "Templates"
         ],
         "summary": "Create a template",
-        "description": "Create a new template that can be used as a starting point for new documents. Templates can optionally be scoped to a specific collection.",
+        "description": "Create a new template that can be used as a starting point for new documents. Templates can optionally be scoped to a specific collection. When `publish` is false the template is saved as a draft visible only to its creator.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8079,7 +8079,6 @@
                   "title": {
                     "type": "string",
                     "description": "The title of the template.",
-                    "minLength": 1,
                     "maxLength": 255
                   },
                   "data": {
@@ -8101,12 +8100,13 @@
                     "type": "string",
                     "format": "uuid",
                     "description": "Identifier for the collection to which the template belongs."
+                  },
+                  "publish": {
+                    "type": "boolean",
+                    "description": "Whether the template is available to other members. Set to false to create a draft visible only to its creator. Defaults to true.",
+                    "default": true
                   }
-                },
-                "required": [
-                  "title",
-                  "data"
-                ]
+                }
               }
             }
           }
@@ -8299,7 +8299,7 @@
           "Templates"
         ],
         "summary": "Update a template",
-        "description": "Update an existing template by its unique identifier.",
+        "description": "Update an existing template by its unique identifier. Draft templates can be made available to other members by passing `publish: true`.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8338,6 +8338,10 @@
                     "format": "uuid",
                     "description": "Identifier for the collection to which the template belongs. Set to null for a workspace-wide template.",
                     "nullable": true
+                  },
+                  "publish": {
+                    "type": "boolean",
+                    "description": "Whether to make a draft template available to other members."
                   }
                 },
                 "required": [

--- a/spec3.yml
+++ b/spec3.yml
@@ -5590,7 +5590,7 @@ paths:
       tags:
         - Templates
       summary: Create a template
-      description: Create a new template that can be used as a starting point for new documents. Templates can optionally be scoped to a specific collection.
+      description: Create a new template that can be used as a starting point for new documents. Templates can optionally be scoped to a specific collection. When `publish` is false the template is saved as a draft visible only to its creator.
       requestBody:
         content:
           application/json:
@@ -5604,7 +5604,6 @@ paths:
                 title:
                   type: string
                   description: The title of the template.
-                  minLength: 1
                   maxLength: 255
                 data:
                   type: object
@@ -5622,9 +5621,10 @@ paths:
                   type: string
                   format: uuid
                   description: Identifier for the collection to which the template belongs.
-              required:
-                - title
-                - data
+                publish:
+                  type: boolean
+                  description: Whether the template is available to other members. Set to false to create a draft visible only to its creator. Defaults to true.
+                  default: true
       responses:
         "200":
           description: OK
@@ -5742,7 +5742,7 @@ paths:
       tags:
         - Templates
       summary: Update a template
-      description: Update an existing template by its unique identifier.
+      description: "Update an existing template by its unique identifier. Draft templates can be made available to other members by passing `publish: true`."
       requestBody:
         content:
           application/json:
@@ -5775,6 +5775,9 @@ paths:
                   format: uuid
                   description: Identifier for the collection to which the template belongs. Set to null for a workspace-wide template.
                   nullable: true
+                publish:
+                  type: boolean
+                  description: Whether to make a draft template available to other members.
               required:
                 - id
       responses:


### PR DESCRIPTION
Documents changes from outline/outline#13357.

Templates can now be saved as drafts visible only to their creator.

- `/templates.create` accepts an optional `publish` flag (defaults to `true`) and no longer requires `title` or `data`, so a blank draft can be persisted as it is being written.
- `/templates.update` accepts a `publish` flag that promotes a draft template to be visible to other members.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzX3eBhjfaks5krZ8mYkBj)_