### PR TITLE
Document filters parameter on /documents.deleted

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -4763,6 +4763,18 @@
                   },
                   {
                     "$ref": "#/components/schemas/Sorting"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "filters": {
+                        "type": "array",
+                        "description": "Structured filter expression, evaluated as an AND of top-level entries. Supported fields are `deletedAt` (date) and `deletedById` (uuid, identifier of the user who deleted the document).",
+                        "items": {
+                          "$ref": "#/components/schemas/DocumentsDeletedFilter"
+                        }
+                      }
+                    }
                   }
                 ]
               }
@@ -8857,6 +8869,71 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/DocumentFilter"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "DocumentsDeletedFilter": {
+        "description": "A single filter node for `/documents.deleted`, either a leaf condition matching a supported field or a group combining nested filters with a logical operator.",
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "A condition that compares a deleted-document field against a value.",
+            "required": [
+              "field",
+              "operator"
+            ],
+            "properties": {
+              "field": {
+                "type": "string",
+                "description": "Name of the field to filter on.",
+                "enum": [
+                  "deletedAt",
+                  "deletedById"
+                ]
+              },
+              "operator": {
+                "type": "string",
+                "description": "Comparison operator to apply. `deletedById` only supports `eq` and `in`.",
+                "enum": [
+                  "eq",
+                  "neq",
+                  "lt",
+                  "lte",
+                  "gt",
+                  "gte",
+                  "in",
+                  "notIn",
+                  "isNull",
+                  "isNotNull"
+                ]
+              },
+              "value": {
+                "description": "Value to compare against. `deletedAt` accepts an ISO 8601 date or an ISO 8601 duration (relative to now); `deletedById` accepts a user UUID (or an array of UUIDs with `in`/`notIn`). Omit for `isNull` and `isNotNull`."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A logical group that combines nested filters with an `AND` or `OR` operator. Groups may themselves contain further groups.",
+            "required": [
+              "operator",
+              "filters"
+            ],
+            "properties": {
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "AND",
+                  "OR"
+                ]
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DocumentsDeletedFilter"
                 }
               }
             }

--- a/spec3.yml
+++ b/spec3.yml
@@ -3484,6 +3484,17 @@ paths:
               allOf:
                 - "$ref": "#/components/schemas/Pagination"
                 - "$ref": "#/components/schemas/Sorting"
+                - type: object
+                  properties:
+                    filters:
+                      type: array
+                      description:
+                        Structured filter expression, evaluated as an AND of
+                        top-level entries. Supported fields are `deletedAt`
+                        (date) and `deletedById` (uuid, identifier of the
+                        user who deleted the document).
+                      items:
+                        "$ref": "#/components/schemas/DocumentsDeletedFilter"
       responses:
         "200":
           description: OK
@@ -6201,6 +6212,63 @@ components:
               type: array
               items:
                 "$ref": "#/components/schemas/DocumentFilter"
+    DocumentsDeletedFilter:
+      description:
+        A single filter node for `/documents.deleted`, either a leaf
+        condition matching a supported field or a group combining nested
+        filters with a logical operator.
+      oneOf:
+        - type: object
+          description: A condition that compares a deleted-document field against a value.
+          required:
+            - field
+            - operator
+          properties:
+            field:
+              type: string
+              description: Name of the field to filter on.
+              enum:
+                - deletedAt
+                - deletedById
+            operator:
+              type: string
+              description:
+                Comparison operator to apply. `deletedById` only supports
+                `eq` and `in`.
+              enum:
+                - eq
+                - neq
+                - lt
+                - lte
+                - gt
+                - gte
+                - in
+                - notIn
+                - isNull
+                - isNotNull
+            value:
+              description:
+                Value to compare against. `deletedAt` accepts an ISO 8601
+                date or an ISO 8601 duration (relative to now); `deletedById`
+                accepts a user UUID (or an array of UUIDs with `in`/`notIn`).
+                Omit for `isNull` and `isNotNull`.
+        - type: object
+          description:
+            A logical group that combines nested filters with an `AND` or
+            `OR` operator. Groups may themselves contain further groups.
+          required:
+            - operator
+            - filters
+          properties:
+            operator:
+              type: string
+              enum:
+                - AND
+                - OR
+            filters:
+              type: array
+              items:
+                "$ref": "#/components/schemas/DocumentsDeletedFilter"
     NavigationNode:
       type: object
       properties:


### PR DESCRIPTION
Adds the new structured `filters` parameter recently introduced upstream for the trash listing endpoint (`/documents.deleted`), along with a dedicated `DocumentsDeletedFilter` component schema describing the condition/group union and the supported fields.

Reflects outline/outline#13474.

## Changes
- `/documents.deleted` request body now accepts an optional `filters` array evaluated as an AND of top-level entries.
- New `DocumentsDeletedFilter` schema mirrors the shape of `DocumentFilter` but restricts `field` to the two fields the endpoint actually supports:
  - `deletedAt` – date (accepts an ISO 8601 date or an ISO 8601 duration relative to now)
  - `deletedById` – uuid of the user who deleted the document (only `eq` and `in` operators)
- Groups (`AND`/`OR`) may nest further filters, matching the DSL used elsewhere.

Only the YAML has been edited; `spec3.json` is regenerated by the pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_018HdXz61n512rW7SAbCBVkT)_