### PR TITLE
Document users.list filters DSL, document preferences, and deletedBy

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -3667,6 +3667,23 @@
                     "type": "boolean",
                     "description": "Whether the document should be displayed in full width"
                   },
+                  "preferences": {
+                    "type": "object",
+                    "nullable": true,
+                    "description": "Document-level display preferences. Only the fields supplied are updated; existing values for other preferences are preserved. Pass `null` to clear all preferences.",
+                    "properties": {
+                      "headingPrefix": {
+                        "type": "string",
+                        "description": "Numbering style applied to the document's headings when rendered.",
+                        "enum": [
+                          "none",
+                          "numeric",
+                          "alphanumeric",
+                          "outline"
+                        ]
+                      }
+                    }
+                  },
                   "createdAt": {
                     "type": "string",
                     "format": "date-time",
@@ -3788,6 +3805,23 @@
                   "fullWidth": {
                     "type": "boolean",
                     "description": "Whether the document should be displayed in full width"
+                  },
+                  "preferences": {
+                    "type": "object",
+                    "nullable": true,
+                    "description": "Document-level display preferences. Only the fields supplied are updated; existing values for other preferences are preserved. Pass `null` to clear all preferences.",
+                    "properties": {
+                      "headingPrefix": {
+                        "type": "string",
+                        "description": "Numbering style applied to the document's headings when rendered.",
+                        "enum": [
+                          "none",
+                          "numeric",
+                          "alphanumeric",
+                          "outline"
+                        ]
+                      }
+                    }
                   },
                   "templateId": {
                     "type": "string",
@@ -7600,9 +7634,17 @@
                         "type": "string",
                         "example": "jane"
                       },
+                      "filters": {
+                        "type": "array",
+                        "description": "Structured filter expression, evaluated as an AND of top-level entries. Cannot be combined with the deprecated `emails`, `role` or `filter` parameters.",
+                        "items": {
+                          "$ref": "#/components/schemas/UserFilter"
+                        }
+                      },
                       "emails": {
                         "type": "array",
-                        "description": "Array of emails",
+                        "deprecated": true,
+                        "description": "Array of emails. Deprecated – prefer the `filters` parameter with an `email` field and the `in` operator.",
                         "items": {
                           "type": "string"
                         },
@@ -7613,7 +7655,8 @@
                       },
                       "filter": {
                         "type": "string",
-                        "description": "The status to filter by",
+                        "deprecated": true,
+                        "description": "The status to filter by. Deprecated – prefer the `filters` parameter (for example filter on `suspendedAt` or `lastActiveAt`).",
                         "enum": [
                           "all",
                           "invited",
@@ -7622,7 +7665,13 @@
                         ]
                       },
                       "role": {
-                        "$ref": "#/components/schemas/UserRole"
+                        "deprecated": true,
+                        "description": "The role to filter by. Deprecated – prefer the `filters` parameter with a `role` field.",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/UserRole"
+                          }
+                        ]
                       }
                     }
                   }
@@ -8958,6 +9007,83 @@
           }
         ]
       },
+      "UserFilter": {
+        "description": "A single filter node for `/users.list`, either a leaf condition matching a user field or a group combining nested filters with a logical operator.",
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "A condition that compares a user field against a value.",
+            "required": [
+              "field",
+              "operator"
+            ],
+            "properties": {
+              "field": {
+                "type": "string",
+                "description": "Name of the user field to filter on.",
+                "enum": [
+                  "id",
+                  "name",
+                  "email",
+                  "role",
+                  "createdAt",
+                  "updatedAt",
+                  "lastActiveAt",
+                  "suspendedAt"
+                ]
+              },
+              "operator": {
+                "type": "string",
+                "description": "Comparison operator to apply. Note that some fields only accept a subset of operators – `id` and `role` only support `eq`, `neq`, `in` and `notIn`.",
+                "enum": [
+                  "eq",
+                  "neq",
+                  "lt",
+                  "lte",
+                  "gt",
+                  "gte",
+                  "contains",
+                  "startsWith",
+                  "endsWith",
+                  "containsStrict",
+                  "startsWithStrict",
+                  "endsWithStrict",
+                  "in",
+                  "notIn",
+                  "isNull",
+                  "isNotNull"
+                ]
+              },
+              "value": {
+                "description": "Value to compare against. May be a string, number, boolean or array of these depending on the field and operator. Date fields accept an ISO 8601 date or an ISO 8601 duration (relative to now). `role` accepts one of the values in `UserRole`. Omit for `isNull` and `isNotNull`."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A logical group that combines nested filters with an `AND` or `OR` operator. Groups may themselves contain further groups.",
+            "required": [
+              "operator",
+              "filters"
+            ],
+            "properties": {
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "AND",
+                  "OR"
+                ]
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/UserFilter"
+                }
+              }
+            }
+          }
+        ]
+      },
       "NavigationNode": {
         "type": "object",
         "properties": {
@@ -9461,6 +9587,32 @@
             "description": "The date and time that this object was deleted",
             "readOnly": true,
             "format": "date-time"
+          },
+          "deletedBy": {
+            "nullable": true,
+            "description": "The user who deleted this document, if any. Only present on deleted documents.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/User"
+              }
+            ]
+          },
+          "preferences": {
+            "type": "object",
+            "nullable": true,
+            "description": "Document-level display preferences.",
+            "properties": {
+              "headingPrefix": {
+                "type": "string",
+                "description": "Numbering style applied to the document's headings when rendered.",
+                "enum": [
+                  "none",
+                  "numeric",
+                  "alphanumeric",
+                  "outline"
+                ]
+              }
+            }
           }
         }
       },

--- a/spec3.yml
+++ b/spec3.yml
@@ -2734,6 +2734,25 @@ paths:
                 fullWidth:
                   type: boolean
                   description: Whether the document should be displayed in full width
+                preferences:
+                  type: object
+                  nullable: true
+                  description:
+                    Document-level display preferences. Only the fields
+                    supplied are updated; existing values for other
+                    preferences are preserved. Pass `null` to clear all
+                    preferences.
+                  properties:
+                    headingPrefix:
+                      type: string
+                      description:
+                        Numbering style applied to the document's headings
+                        when rendered.
+                      enum:
+                        - none
+                        - numeric
+                        - alphanumeric
+                        - outline
                 createdAt:
                   type: string
                   format: date-time
@@ -2817,6 +2836,25 @@ paths:
                 fullWidth:
                   type: boolean
                   description: Whether the document should be displayed in full width
+                preferences:
+                  type: object
+                  nullable: true
+                  description:
+                    Document-level display preferences. Only the fields
+                    supplied are updated; existing values for other
+                    preferences are preserved. Pass `null` to clear all
+                    preferences.
+                  properties:
+                    headingPrefix:
+                      type: string
+                      description:
+                        Numbering style applied to the document's headings
+                        when rendered.
+                      enum:
+                        - none
+                        - numeric
+                        - alphanumeric
+                        - outline
                 templateId:
                   type: string
                   format: uuid
@@ -5338,9 +5376,20 @@ paths:
                     query:
                       type: string
                       example: jane
+                    filters:
+                      type: array
+                      description:
+                        Structured filter expression, evaluated as an AND of
+                        top-level entries. Cannot be combined with the
+                        deprecated `emails`, `role` or `filter` parameters.
+                      items:
+                        "$ref": "#/components/schemas/UserFilter"
                     emails:
                       type: array
-                      description: Array of emails
+                      deprecated: true
+                      description:
+                        Array of emails. Deprecated – prefer the `filters`
+                        parameter with an `email` field and the `in` operator.
                       items:
                         type: string
                       example:
@@ -5348,14 +5397,23 @@ paths:
                         - prudence.crandall@mail.com
                     filter:
                       type: string
-                      description: The status to filter by
+                      deprecated: true
+                      description:
+                        The status to filter by. Deprecated – prefer the
+                        `filters` parameter (for example filter on
+                        `suspendedAt` or `lastActiveAt`).
                       enum:
                         - all
                         - invited
                         - active
                         - suspended
                     role:
-                      "$ref": "#/components/schemas/UserRole"
+                      deprecated: true
+                      description:
+                        The role to filter by. Deprecated – prefer the
+                        `filters` parameter with a `role` field.
+                      allOf:
+                        - "$ref": "#/components/schemas/UserRole"
       responses:
         "200":
           description: OK
@@ -6287,6 +6345,77 @@ components:
               type: array
               items:
                 "$ref": "#/components/schemas/DocumentsDeletedFilter"
+    UserFilter:
+      description:
+        A single filter node for `/users.list`, either a leaf condition
+        matching a user field or a group combining nested filters with a
+        logical operator.
+      oneOf:
+        - type: object
+          description: A condition that compares a user field against a value.
+          required:
+            - field
+            - operator
+          properties:
+            field:
+              type: string
+              description: Name of the user field to filter on.
+              enum:
+                - id
+                - name
+                - email
+                - role
+                - createdAt
+                - updatedAt
+                - lastActiveAt
+                - suspendedAt
+            operator:
+              type: string
+              description:
+                Comparison operator to apply. Note that some fields only
+                accept a subset of operators – `id` and `role` only support
+                `eq`, `neq`, `in` and `notIn`.
+              enum:
+                - eq
+                - neq
+                - lt
+                - lte
+                - gt
+                - gte
+                - contains
+                - startsWith
+                - endsWith
+                - containsStrict
+                - startsWithStrict
+                - endsWithStrict
+                - in
+                - notIn
+                - isNull
+                - isNotNull
+            value:
+              description:
+                Value to compare against. May be a string, number, boolean
+                or array of these depending on the field and operator. Date
+                fields accept an ISO 8601 date or an ISO 8601 duration
+                (relative to now). `role` accepts one of the values in
+                `UserRole`. Omit for `isNull` and `isNotNull`.
+        - type: object
+          description:
+            A logical group that combines nested filters with an `AND` or
+            `OR` operator. Groups may themselves contain further groups.
+          required:
+            - operator
+            - filters
+          properties:
+            operator:
+              type: string
+              enum:
+                - AND
+                - OR
+            filters:
+              type: array
+              items:
+                "$ref": "#/components/schemas/UserFilter"
     NavigationNode:
       type: object
       properties:
@@ -6678,6 +6807,28 @@ components:
           description: The date and time that this object was deleted
           readOnly: true
           format: date-time
+        deletedBy:
+          nullable: true
+          description:
+            The user who deleted this document, if any. Only present on
+            deleted documents.
+          allOf:
+            - "$ref": "#/components/schemas/User"
+        preferences:
+          type: object
+          nullable: true
+          description: Document-level display preferences.
+          properties:
+            headingPrefix:
+              type: string
+              description:
+                Numbering style applied to the document's headings when
+                rendered.
+              enum:
+                - none
+                - numeric
+                - alphanumeric
+                - outline
     DocumentInsight:
       type: object
       description: A rollup of activity counts for a document over a daily or weekly


### PR DESCRIPTION
Picks up API changes merged in outline/outline over the last day.

## Summary

- **`/users.list` — new `filters` parameter (from outline/outline#13456).**
  Adds the structured `filters` request parameter using a new shared
  `UserFilter` schema that mirrors the existing `DocumentFilter` pattern
  (fields: `id`, `name`, `email`, `role`, `createdAt`, `updatedAt`,
  `lastActiveAt`, `suspendedAt`). Marks the existing `emails`, `filter`
  and `role` request parameters as deprecated since they cannot be
  combined with `filters`.
- **`/documents.create` and `/documents.update` — new `preferences`
  parameter (from outline/outline#13522, outline/outline#13525).** Adds
  the new document-level `preferences` object with a `headingPrefix`
  enum (`none`, `numeric`, `alphanumeric`, `outline`). Explicit `null`
  is accepted to clear preferences.
- **`Document` response schema.** Surfaces the new `preferences` field
  and the new `deletedBy` field (from outline/outline#13484), populated
  for soft-deleted documents.

Only `spec3.yml` was hand-edited; `spec3.json` is regenerated by the
pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe7c1xAZ3rJFXCQ92dAKaY)_