### PR TITLE
Document okf format on collections.export and collections.export_all

### DIFF
--- a/spec3.json
+++ b/spec3.json
@@ -2160,7 +2160,8 @@
                     "enum": [
                       "outline-markdown",
                       "json",
-                      "html"
+                      "html",
+                      "okf"
                     ]
                   },
                   "id": {
@@ -2229,7 +2230,8 @@
                     "enum": [
                       "outline-markdown",
                       "json",
-                      "html"
+                      "html",
+                      "okf"
                     ]
                   },
                   "includeAttachments": {

--- a/spec3.yml
+++ b/spec3.yml
@@ -1669,6 +1669,7 @@ paths:
                     - outline-markdown
                     - json
                     - html
+                    - okf
                 id:
                   type: string
                   format: uuid
@@ -1713,6 +1714,7 @@ paths:
                     - outline-markdown
                     - json
                     - html
+                    - okf
                 includeAttachments:
                   type: boolean
                   description: Whether to include attachments in the export.


### PR DESCRIPTION
Outline added support for the Open Knowledge Format (OKF) as a new file operation format in outline/outline#13644. This exposes the new `okf` value in the format enum for both bulk collection export endpoints.

- `collections.export` accepts the new `okf` value in `format`
- `collections.export_all` accepts the new `okf` value in `format`

Import (`collections.import`) is not affected — the underlying schema still restricts imports to `outline-markdown` and `json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m9RsQvDqxHxoDv8RNGutj

---
_Generated by [Claude Code](https://claude.ai/code/session_018m9RsQvDqxHxoDv8RNGutj)_